### PR TITLE
ci: reconcile Dependabot workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     name: GitHub Actions syntax and semantics
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: infra/cloudflare/go.mod
           cache: false
@@ -24,7 +24,7 @@ jobs:
     name: Protocol compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
@@ -63,7 +63,7 @@ jobs:
         working-directory: infra/cloudflare
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: infra/cloudflare/go.mod
           cache-dependency-path: infra/cloudflare/go.sum
@@ -88,10 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
-          components: clippy,rustfmt
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal --component clippy --component rustfmt
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       - run: cargo fmt --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
@@ -101,9 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       - run: cargo test --locked
 
@@ -112,11 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
-          components: clippy,rustfmt
-          targets: wasm32-unknown-unknown
+      - name: Install pinned Rust toolchain
+        run: >-
+          rustup toolchain install 1.94.1 --profile minimal
+          --component clippy --component rustfmt --target wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: console -> target
@@ -183,9 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       # SableDB compiles a whole database from source; build it through the layer

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,6 +3,7 @@ name: Protocol fuzzing
 on:
   pull_request:
     paths:
+      - ".github/workflows/fuzz.yml"
       - "fuzz/**"
       - "proto/**"
       - "src/analytics.rs"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,10 +24,9 @@ jobs:
       # Override rust-toolchain.toml for cargo-fuzz and every Cargo/rustc child it starts.
       RUSTUP_TOOLCHAIN: nightly-2026-08-01
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9
-        with:
-          toolchain: nightly-2026-08-01
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned fuzz toolchain
+        run: rustup toolchain install nightly-2026-08-01 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: fuzz

--- a/.github/workflows/native-packaging.yml
+++ b/.github/workflows/native-packaging.yml
@@ -31,10 +31,9 @@ jobs:
       run:
         working-directory: console
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: console

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,8 @@ jobs:
               exit 1
             fi
           done
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       - run: cargo fmt --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
@@ -90,14 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9 # 1.94.1
-        with:
-          toolchain: 1.94.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build the pinned SableDB image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./sabledb/Dockerfile
@@ -106,7 +104,7 @@ jobs:
           cache-from: type=gha,scope=sabledb-image
           cache-to: type=gha,scope=sabledb-image,mode=max
       - name: Build the release-candidate API image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true
@@ -114,7 +112,7 @@ jobs:
           cache-from: type=gha,scope=rustyauth-image
           cache-to: type=gha,scope=rustyauth-image,mode=max
       - name: Build the release-candidate dashboard image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.dashboard
@@ -168,10 +166,9 @@ jobs:
       # Override rust-toolchain.toml for cargo-fuzz and every Cargo/rustc child it starts.
       RUSTUP_TOOLCHAIN: nightly-2026-08-01
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9
-        with:
-          toolchain: nightly-2026-08-01
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned fuzz toolchain
+        run: rustup toolchain install nightly-2026-08-01 --profile minimal
       - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
         with:
           workspaces: fuzz
@@ -187,7 +184,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: JSR packages exist and the target version is unused
         env:
           RELEASE_TAG: ${{ github.ref_name }}
@@ -368,7 +365,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0


### PR DESCRIPTION
## Summary

- applies the GitHub Actions versions from #17 to every workflow added or changed by #19
- replaces ignored `dtolnay/rust-toolchain` `toolchain:` inputs with explicit pinned `rustup` installs
- corrects action-version comments and preserves SHA pinning

## Dependency PR reconciliation

- #17: this PR completes the action updates across the post-#19 workflow tree
- #16: six compatible Cargo upgrades already landed through #19; Buffa remains pinned at 0.8.1 because ConnectRPC 0.8.1/build 0.8.0 is not compatible with Buffa 0.9

## Validation

- Actionlint 1.7.12
- `deno task check`
- stable and nightly `rustup toolchain install` command replay
- `git diff --check`
- Gitleaks 8.28.0 staged scan

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reconciles GitHub Actions versions across CI, fuzzing, native packaging, and release workflows while preserving SHA pinning.
- Replaces `dtolnay/rust-toolchain` steps with explicit pinned `rustup toolchain install` commands.
- Upgrades checkout, Go setup, Buildx, and Docker build actions.
- Ensures changes to the fuzz workflow itself trigger its pull-request checks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code failures identified.

The updated workflows retain SHA-pinned actions, preserve required Rust toolchain selection and components, and use compatible action inputs already exercised by sibling jobs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updates pinned action versions and replaces Rust setup actions with equivalent explicit toolchain installations, including required components and the WebAssembly target. |
| .github/workflows/fuzz.yml | Adds self-trigger coverage and explicitly installs the pinned nightly toolchain selected by the job environment. |
| .github/workflows/native-packaging.yml | Updates checkout and replaces the Rust setup action with an explicit installation compatible with repository toolchain selection. |
| .github/workflows/release.yml | Reconciles pinned action versions and explicit stable/nightly Rust installations without establishing a changed-code release failure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: qualify fuzz workflow changes"](https://github.com/rusty-auth/rustyauth/commit/5e4dc54c5db7b0a3874af675ba26af4afcb28fbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51588904)</sub>

<!-- /greptile_comment -->