### PR TITLE
build: finish Dependabot reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal --component clippy --component rustfmt
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo fmt --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --locked
 
   console:
@@ -113,7 +113,7 @@ jobs:
         run: >-
           rustup toolchain install 1.94.1 --profile minimal
           --component clippy --component rustfmt --target wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: console -> target
       - name: Install Linux native console dependencies
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       # SableDB compiles a whole database from source; build it through the layer
       # cache once per pinned revision instead of from scratch every run, and load

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned fuzz toolchain
         run: rustup toolchain install nightly-2026-08-01 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: fuzz
       - run: cargo install cargo-fuzz --version 0.13.2 --locked

--- a/.github/workflows/native-packaging.yml
+++ b/.github/workflows/native-packaging.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: console
       - name: Install Linux native dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           done
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo fmt --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - run: cargo test --locked
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build the pinned SableDB image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned fuzz toolchain
         run: rustup toolchain install nightly-2026-08-01 --profile minimal
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: fuzz
       - run: cargo install cargo-fuzz --version 0.13.2 --locked

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Base images are pinned by digest so a rebuild cannot silently pick up a re-tagged upstream image.
 # Refresh a digest with `docker buildx imagetools inspect <image>:<tag>` and update the tag with it.
-FROM rust:1.94.1-slim-bookworm@sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2 AS build
+FROM rust:1.97.1-slim-bookworm@sha256:96c0af8cf054fd006435089f0076729716784ec9be485bd655de59c55df105ce AS build
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends clang libssl-dev pkg-config \

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,6 +1,6 @@
 # The Dioxus dashboard is a separate, stateless artifact. It receives no
 # datastore or RustyAuth master credentials and proxies only named API paths.
-FROM rust:1.94.1-slim-bookworm@sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2 AS build
+FROM rust:1.97.1-slim-bookworm@sha256:96c0af8cf054fd006435089f0076729716784ec9be485bd655de59c55df105ce AS build
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends clang curl libssl-dev pkg-config \


### PR DESCRIPTION
## Summary

- upgrade the digest-pinned Rust builder images to 1.97.1 from #20
- apply the remaining Rust cache action update from #23 across every current workflow
- preserve the post-#22 workflow hardening instead of merging stale pre-#22 workflow content

Supersedes #20 and #23 while including all of their changes together on current main. PR #23 is the rebased remaining portion of the earlier #21 action group.

## Local qualification

- deno task check
- Actionlint 1.7.12 across all workflows
- git diff --check
- Gitleaks 8.28.0 on the staged diff
- verified the Rust 1.97.1 multi-platform digest directly with Docker Buildx

Native clients remain preview-only; this change does not add them to the GA release path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reconciles two dependency updates by moving the API and dashboard container builders to digest-pinned Rust 1.97.1 images and applying the updated Rust cache action revision consistently across current workflows.

- Updates Rust cache action pins in CI, fuzzing, native packaging, and release workflows.
- Updates both application builder images while retaining scratch runtime stages.
- Preserves the existing workflow hardening and release topology.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The changes are limited to pinned builder-image and cache-action revisions, and the existing workflow inputs, supported runner environments, build targets, and hardened runtime stages remain intact.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updates the Rust cache action pin consistently across all Rust CI jobs without changing job inputs or execution order. |
| .github/workflows/fuzz.yml | Updates the cache action pin while preserving the pinned nightly toolchain and fuzz workspace configuration. |
| .github/workflows/native-packaging.yml | Applies the cache action update uniformly to the existing macOS, Windows, and Linux preview packaging matrix. |
| .github/workflows/release.yml | Updates cache action pins in release verification, qualification, and fuzz jobs without altering publication dependencies or permissions. |
| Dockerfile | Updates the digest-pinned Rust builder from 1.94.1 to 1.97.1 while leaving the build and scratch runtime construction unchanged. |
| Dockerfile.dashboard | Updates the dashboard Rust builder to the same pinned 1.97.1 image while preserving the Dioxus build, gateway, and scratch runtime stages. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build: finish Dependabot reconciliation"](https://github.com/rusty-auth/rustyauth/commit/6698504a268737f1d625c42e6e86e3624d1d1b6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51592708)</sub>

<!-- /greptile_comment -->