### PR TITLE
ci: automate Railway deployments from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       - run: deno task docs:check
       - run: deno task gateway:check
       - run: deno task native:check
+      - run: deno task railway:check
+      - run: deno task railway:test
       - run: deno task release:test
       - run: deno task site:check
       - run: deno task site:test

--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -246,6 +246,19 @@ jobs:
             --project "${RAILWAY_PROJECT_ID}" \
             --environment "${RAILWAY_ENVIRONMENT_ID}" \
             --service "${RAILWAY_API_SERVICE_ID}" --json >/dev/null
+      - name: Create deployment receipt directory
+        run: mkdir -p "${RUNNER_TEMP}/railway-receipts"
+      - name: Capture the current browser origin configuration
+        run: |
+          railway variable list \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_ID}" \
+            --service "${RAILWAY_API_SERVICE_ID}" --json \
+            | jq '{AUTH_ISSUER, WEBAUTHN_RP_ORIGIN, WEBAUTHN_RP_ID}' \
+              > "${RUNNER_TEMP}/railway-receipts/browser-origin-before.json"
+          jq --exit-status \
+            '.AUTH_ISSUER and .WEBAUTHN_RP_ORIGIN and .WEBAUTHN_RP_ID' \
+            "${RUNNER_TEMP}/railway-receipts/browser-origin-before.json" >/dev/null
       - name: Align the browser issuer and relying-party origin
         run: |
           dashboard_url="${RAILWAY_DASHBOARD_URL%/}"
@@ -262,8 +275,6 @@ jobs:
             "AUTH_ISSUER=${dashboard_url}" \
             "WEBAUTHN_RP_ORIGIN=${dashboard_url}" \
             "WEBAUTHN_RP_ID=${dashboard_host}" >/dev/null
-      - name: Create deployment receipt directory
-        run: mkdir -p "${RUNNER_TEMP}/railway-receipts"
       - name: Deploy realm API
         run: >-
           deno run --allow-env --allow-net --allow-run --allow-write="${RUNNER_TEMP}/railway-receipts"
@@ -303,6 +314,68 @@ jobs:
           --health-url "${RAILWAY_API_URL%/}/readyz"
           --health-url "${RAILWAY_DASHBOARD_URL%/}/readyz"
           --receipt "${RUNNER_TEMP}/railway-receipts/sabledb.json"
+      - name: Restore the previous Railway deployment set
+        if: failure()
+        run: |
+          rollback_failed=0
+          rollback_service() {
+            receipt="$1"
+            [[ -f "${receipt}" ]] || return 0
+            [[ "$(jq -r '.changed' "${receipt}")" == "true" ]] || return 0
+
+            service="$(jq -r '.service' "${receipt}")"
+            profile="$(jq -r '.profile' "${receipt}")"
+            previous_image="$(jq -r '.previousImage // empty' "${receipt}")"
+            previous_digest="$(jq -r '.previousDigest // empty' "${receipt}")"
+            base="$(basename "${receipt}" .json)"
+            if [[ -z "${previous_image}" || -z "${previous_digest}" ]]; then
+              railway down \
+                --project "${RAILWAY_PROJECT_ID}" \
+                --environment "${RAILWAY_ENVIRONMENT_ID}" \
+                --service "${service}" --yes || rollback_failed=1
+              return 0
+            fi
+
+            health_args=()
+            while IFS= read -r url; do
+              health_args+=(--health-url "${url}")
+            done < <(jq -r '.healthUrls[]' "${receipt}")
+            deno run \
+              --allow-env --allow-net --allow-run \
+              --allow-write="${RUNNER_TEMP}/railway-receipts" \
+              scripts/railway-rollout.ts \
+              --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT_ID}" \
+              --service "${service}" \
+              --profile "${profile}" \
+              --image "${previous_image}" \
+              --digest "${previous_digest}" \
+              "${health_args[@]}" \
+              --receipt "${RUNNER_TEMP}/railway-receipts/rollback-${base}.json" \
+              || rollback_failed=1
+          }
+
+          rollback_service "${RUNNER_TEMP}/railway-receipts/sabledb.json"
+          rollback_service "${RUNNER_TEMP}/railway-receipts/dashboard.json"
+
+          origin_receipt="${RUNNER_TEMP}/railway-receipts/browser-origin-before.json"
+          if [[ -f "${origin_receipt}" ]]; then
+            previous_issuer="$(jq -r '.AUTH_ISSUER' "${origin_receipt}")"
+            previous_origin="$(jq -r '.WEBAUTHN_RP_ORIGIN' "${origin_receipt}")"
+            previous_rp_id="$(jq -r '.WEBAUTHN_RP_ID' "${origin_receipt}")"
+            railway variable set \
+              --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT_ID}" \
+              --service "${RAILWAY_API_SERVICE_ID}" \
+              --skip-deploys --json \
+              "AUTH_ISSUER=${previous_issuer}" \
+              "WEBAUTHN_RP_ORIGIN=${previous_origin}" \
+              "WEBAUTHN_RP_ID=${previous_rp_id}" >/dev/null \
+              || rollback_failed=1
+          fi
+
+          rollback_service "${RUNNER_TEMP}/railway-receipts/api.json"
+          exit "${rollback_failed}"
       - name: Show bounded deployment logs on failure
         if: failure()
         run: |

--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -1,0 +1,324 @@
+name: Railway production deployment
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Full main-branch commit SHA to deploy; blank selects the current main tip
+        required: false
+        type: string
+      allow_non_tip:
+        description: Allow an older main commit for an explicit rollback
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: railway-production
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Select verified main commit
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.release.outputs.deploy }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - id: release
+        name: Reject stale or non-main automatic deployments
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+          ALLOW_NON_TIP: ${{ inputs.allow_non_tip }}
+        run: |
+          git fetch --no-tags origin main
+          tip="$(git rev-parse origin/main)"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            candidate="$(jq -r '.workflow_run.head_sha' "${GITHUB_EVENT_PATH}")"
+            allow_non_tip=false
+          else
+            candidate="${REQUESTED_SHA:-${tip}}"
+            allow_non_tip="${ALLOW_NON_TIP:-false}"
+          fi
+          if [[ ! "${candidate}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::deployment commit must be a full lowercase SHA"
+            exit 1
+          fi
+          git cat-file -e "${candidate}^{commit}"
+          if ! git merge-base --is-ancestor "${candidate}" "${tip}"; then
+            echo "::error::deployment commit is not on main"
+            exit 1
+          fi
+          if [[ "${candidate}" != "${tip}" && "${allow_non_tip}" != "true" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+              echo "Skipping stale successful CI result ${candidate}; main is now ${tip}."
+              echo "deploy=false" >> "${GITHUB_OUTPUT}"
+              echo "sha=${candidate}" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "::error::an older main commit requires allow_non_tip for an explicit rollback"
+            exit 1
+          fi
+          echo "deploy=true" >> "${GITHUB_OUTPUT}"
+          echo "sha=${candidate}" >> "${GITHUB_OUTPUT}"
+
+  publish-api:
+    name: Publish API candidate
+    needs: prepare
+    if: needs.prepare.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
+          tags: ghcr.io/rusty-auth/rustyauth:main-${{ needs.prepare.outputs.sha }}
+          cache-from: type=gha,scope=rustyauth-image
+          cache-to: type=gha,scope=rustyauth-image,mode=max
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Sign API candidate by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/rusty-auth/rustyauth@${DIGEST}"
+
+  publish-dashboard:
+    name: Publish dashboard candidate
+    needs: prepare
+    if: needs.prepare.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile.dashboard
+          push: true
+          platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
+          tags: ghcr.io/rusty-auth/dashboard:main-${{ needs.prepare.outputs.sha }}
+          cache-from: type=gha,scope=dashboard-image
+          cache-to: type=gha,scope=dashboard-image,mode=max
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Sign dashboard candidate by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/rusty-auth/dashboard@${DIGEST}"
+
+  publish-sabledb:
+    name: Publish SableDB candidate
+    needs: prepare
+    if: needs.prepare.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: sabledb/Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
+          tags: ghcr.io/rusty-auth/sabledb:main-${{ needs.prepare.outputs.sha }}
+          cache-from: type=gha,scope=sabledb-image
+          cache-to: type=gha,scope=sabledb-image,mode=max
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Sign SableDB candidate by digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/rusty-auth/sabledb@${DIGEST}"
+
+  deploy:
+    name: Roll out verified candidate
+    needs: [prepare, publish-api, publish-dashboard, publish-sabledb]
+    if: needs.prepare.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment:
+      name: railway-production
+      url: ${{ vars.RAILWAY_DASHBOARD_URL }}
+    env:
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_API_SERVICE_ID: ${{ vars.RAILWAY_API_SERVICE_ID }}
+      RAILWAY_DASHBOARD_SERVICE_ID: ${{ vars.RAILWAY_DASHBOARD_SERVICE_ID }}
+      RAILWAY_SABLEDB_SERVICE_ID: ${{ vars.RAILWAY_SABLEDB_SERVICE_ID }}
+      RAILWAY_API_URL: ${{ vars.RAILWAY_API_URL }}
+      RAILWAY_DASHBOARD_URL: ${{ vars.RAILWAY_DASHBOARD_URL }}
+      RAILWAY_AGENT_SESSION: github-${{ github.run_id }}-${{ github.run_attempt }}
+      RELEASE_SHA: ${{ needs.prepare.outputs.sha }}
+      API_DIGEST: ${{ needs.publish-api.outputs.digest }}
+      DASHBOARD_DIGEST: ${{ needs.publish-dashboard.outputs.digest }}
+      SABLEDB_DIGEST: ${{ needs.publish-sabledb.outputs.digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
+        with:
+          deno-version: 2.9.3
+      - name: Install pinned Railway CLI
+        run: npm install --global @railway/cli@5.31.0
+      - name: Validate deployment target
+        run: |
+          required=(
+            RAILWAY_API_TOKEN RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID
+            RAILWAY_API_SERVICE_ID RAILWAY_DASHBOARD_SERVICE_ID RAILWAY_SABLEDB_SERVICE_ID
+            RAILWAY_API_URL RAILWAY_DASHBOARD_URL API_DIGEST DASHBOARD_DIGEST SABLEDB_DIGEST
+          )
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::GitHub environment railway-production is missing ${name}"
+              exit 1
+            fi
+          done
+          [[ "${RAILWAY_API_URL}" == https://* ]]
+          [[ "${RAILWAY_DASHBOARD_URL}" == https://* ]]
+          railway service status \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_ID}" \
+            --service "${RAILWAY_API_SERVICE_ID}" --json >/dev/null
+      - name: Align the browser issuer and relying-party origin
+        run: |
+          dashboard_url="${RAILWAY_DASHBOARD_URL%/}"
+          dashboard_host="${dashboard_url#https://}"
+          if [[ "${dashboard_host}" == */* || -z "${dashboard_host}" ]]; then
+            echo "::error::RAILWAY_DASHBOARD_URL must be an HTTPS origin without a path"
+            exit 1
+          fi
+          railway variable set \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_ID}" \
+            --service "${RAILWAY_API_SERVICE_ID}" \
+            --skip-deploys --json \
+            "AUTH_ISSUER=${dashboard_url}" \
+            "WEBAUTHN_RP_ORIGIN=${dashboard_url}" \
+            "WEBAUTHN_RP_ID=${dashboard_host}" >/dev/null
+      - name: Create deployment receipt directory
+        run: mkdir -p "${RUNNER_TEMP}/railway-receipts"
+      - name: Deploy realm API
+        run: >-
+          deno run --allow-env --allow-net --allow-run --allow-write="${RUNNER_TEMP}/railway-receipts"
+          scripts/railway-rollout.ts
+          --project "${RAILWAY_PROJECT_ID}"
+          --environment "${RAILWAY_ENVIRONMENT_ID}"
+          --service "${RAILWAY_API_SERVICE_ID}"
+          --profile realm
+          --image "ghcr.io/rusty-auth/rustyauth:main-${RELEASE_SHA}"
+          --digest "${API_DIGEST}"
+          --health-url "${RAILWAY_API_URL%/}/healthz"
+          --health-url "${RAILWAY_API_URL%/}/readyz"
+          --receipt "${RUNNER_TEMP}/railway-receipts/api.json"
+      - name: Deploy dashboard
+        run: >-
+          deno run --allow-env --allow-net --allow-run --allow-write="${RUNNER_TEMP}/railway-receipts"
+          scripts/railway-rollout.ts
+          --project "${RAILWAY_PROJECT_ID}"
+          --environment "${RAILWAY_ENVIRONMENT_ID}"
+          --service "${RAILWAY_DASHBOARD_SERVICE_ID}"
+          --profile dashboard
+          --image "ghcr.io/rusty-auth/dashboard:main-${RELEASE_SHA}"
+          --digest "${DASHBOARD_DIGEST}"
+          --health-url "${RAILWAY_DASHBOARD_URL%/}/healthz"
+          --health-url "${RAILWAY_DASHBOARD_URL%/}/readyz"
+          --receipt "${RUNNER_TEMP}/railway-receipts/dashboard.json"
+      - name: Deploy private SableDB
+        run: >-
+          deno run --allow-env --allow-net --allow-run --allow-write="${RUNNER_TEMP}/railway-receipts"
+          scripts/railway-rollout.ts
+          --project "${RAILWAY_PROJECT_ID}"
+          --environment "${RAILWAY_ENVIRONMENT_ID}"
+          --service "${RAILWAY_SABLEDB_SERVICE_ID}"
+          --profile sabledb
+          --image "ghcr.io/rusty-auth/sabledb:main-${RELEASE_SHA}"
+          --digest "${SABLEDB_DIGEST}"
+          --health-url "${RAILWAY_API_URL%/}/readyz"
+          --health-url "${RAILWAY_DASHBOARD_URL%/}/readyz"
+          --receipt "${RUNNER_TEMP}/railway-receipts/sabledb.json"
+      - name: Show bounded deployment logs on failure
+        if: failure()
+        run: |
+          for service in \
+            "${RAILWAY_API_SERVICE_ID}" \
+            "${RAILWAY_DASHBOARD_SERVICE_ID}" \
+            "${RAILWAY_SABLEDB_SERVICE_ID}"; do
+            railway logs --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT_ID}" \
+              --service "${service}" --latest --deployment --lines 100 || true
+          done
+      - name: Retain deployment receipts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: railway-production-${{ needs.prepare.outputs.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/railway-receipts/*.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
       - run: deno task docs:check
       - run: deno task gateway:check
       - run: deno task native:check
+      - run: deno task railway:check
+      - run: deno task railway:test
       - run: deno task release:test
       - run: deno task site:check
       - run: deno task site:test

--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,7 @@
     "gateway:check": "deno run --allow-read scripts/check-dashboard-gateway.ts",
     "native:check": "deno run --allow-read scripts/check-native-packaging.ts",
     "railway:check": "deno check scripts/railway-rollout.ts",
-    "railway:test": "deno test --allow-read scripts/railway-rollout.test.ts scripts/railway-workflow.test.ts",
+    "railway:test": "deno test --allow-read --allow-write scripts/railway-rollout.test.ts scripts/railway-workflow.test.ts",
     "release:check": "deno run --allow-read scripts/check-release-readiness.ts",
     "release:test": "deno test --allow-read scripts/check-release-readiness.test.ts",
     "console:dev": "cd console && dx serve --web",

--- a/deno.json
+++ b/deno.json
@@ -13,6 +13,8 @@
     "docs:check": "deno run --allow-read scripts/check-docs-links.ts",
     "gateway:check": "deno run --allow-read scripts/check-dashboard-gateway.ts",
     "native:check": "deno run --allow-read scripts/check-native-packaging.ts",
+    "railway:check": "deno check scripts/railway-rollout.ts",
+    "railway:test": "deno test --allow-read scripts/railway-rollout.test.ts scripts/railway-workflow.test.ts",
     "release:check": "deno run --allow-read scripts/check-release-readiness.ts",
     "release:test": "deno test --allow-read scripts/check-release-readiness.test.ts",
     "console:dev": "cd console && dx serve --web",
@@ -31,8 +33,8 @@
     "fmt": "cargo fmt && cargo fmt --manifest-path console/Cargo.toml && deno fmt deno.json buf.yaml buf.gen.yaml packages/client packages/protocol/deno.json packages/protocol/index.ts release-evidence scripts site/src site/tests site/astro.config.mjs site/deno.json site/package.json",
     "fmt:check": "cargo fmt --check && cargo fmt --manifest-path console/Cargo.toml --check && deno fmt --check deno.json buf.yaml buf.gen.yaml packages/client packages/protocol/deno.json packages/protocol/index.ts release-evidence scripts site/src site/tests site/astro.config.mjs site/deno.json site/package.json && cd infra/cloudflare && test -z \"$(gofmt -l .)\"",
     "lint": "cargo clippy --locked --all-targets --all-features -- -D warnings && cargo clippy --manifest-path console/Cargo.toml --locked --no-default-features --features web -- -D warnings && deno lint packages/client/src packages/protocol/index.ts scripts site/src site/tests site/astro.config.mjs && cd infra/cloudflare && go vet ./...",
-    "check": "deno task fmt:check && deno task lint && deno task connect:check && deno task docs:check && deno task gateway:check && deno task native:check && deno task site:check",
-    "test": "deno task connect:test && deno task release:test && deno task site:test && cargo test --locked && cd infra/cloudflare && go test ./..."
+    "check": "deno task fmt:check && deno task lint && deno task connect:check && deno task docs:check && deno task gateway:check && deno task native:check && deno task railway:check && deno task site:check",
+    "test": "deno task connect:test && deno task railway:test && deno task release:test && deno task site:test && cargo test --locked && cd infra/cloudflare && go test ./..."
   },
   "fmt": {
     "lineWidth": 110,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -81,8 +81,8 @@ the older result is recorded as skipped rather than being allowed to roll produc
 
 Each merge publishes separate API, dashboard and SableDB images under a full-commit tag. The images include
 SBOM and provenance attestations and are signed by GitHub OIDC. Railway is updated to that exact tag, and the
-rollout accepts success only when Railway reports the expected registry digest in a terminal `SUCCESS`
-deployment. Mutable `latest` tags are never used by this path.
+rollout sends Railway a digest reference rather than a tag and accepts success only when Railway reports that
+digest in a terminal `SUCCESS` deployment. Mutable `latest` tags are never used by this path.
 
 Rollouts are serialized across the state boundaries:
 
@@ -92,6 +92,12 @@ Rollouts are serialized across the state boundaries:
    upstream readiness check.
 3. Private SableDB is replaced without recreating its volume, after which both API and dashboard readiness
    are checked again.
+
+Before the first mutation, the workflow records the active deployment and browser-origin configuration. A
+later deployment or readiness failure restores every completed service in reverse order, restores the prior
+issuer and relying-party values, and retains both forward and rollback receipts. If a newly introduced service
+had no prior deployment, rollback removes only that service's latest deployment; it never deletes the service
+or a datastore volume. A rollback failure keeps the workflow red and requires operator repair.
 
 The GitHub `railway-production` environment owns the workspace-scoped `RAILWAY_API_TOKEN` and non-secret
 target IDs/URLs. The token is restricted to the Railway workspace containing this project; project-scoped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -72,6 +72,41 @@ backup bucket is a project resource rather than a running service:
 The bucket remains optional, but any deployment claiming recovery must configure it and complete a restore
 drill.
 
+### Automatic maintained-template upgrades
+
+The maintained Railway production/template-source project follows successful merges to `main` through
+`.github/workflows/railway-production.yml`. The workflow starts only after the repository's `CI` workflow has
+completed successfully for the current `main` tip. A later merge makes an older successful result stale, so
+the older result is recorded as skipped rather than being allowed to roll production backwards.
+
+Each merge publishes separate API, dashboard and SableDB images under a full-commit tag. The images include
+SBOM and provenance attestations and are signed by GitHub OIDC. Railway is updated to that exact tag, and the
+rollout accepts success only when Railway reports the expected registry digest in a terminal `SUCCESS`
+deployment. Mutable `latest` tags are never used by this path.
+
+Rollouts are serialized across the state boundaries:
+
+1. The realm API runs the target image's `rustyauth doctor` as a Railway pre-deploy command, then reaches
+   `/healthz` and `/readyz` on the application API origin.
+2. The stateless dashboard deploys and reaches both probes through its public origin, including its private
+   upstream readiness check.
+3. Private SableDB is replaced without recreating its volume, after which both API and dashboard readiness
+   are checked again.
+
+The GitHub `railway-production` environment owns the workspace-scoped `RAILWAY_API_TOKEN` and non-secret
+target IDs/URLs. The token is restricted to the Railway workspace containing this project; project-scoped
+tokens are preferred when the workspace permits their creation. The environment must define
+`RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_API_SERVICE_ID`,
+`RAILWAY_DASHBOARD_SERVICE_ID`, `RAILWAY_SABLEDB_SERVICE_ID`, `RAILWAY_API_URL` and
+`RAILWAY_DASHBOARD_URL`. The job aligns the issuer and WebAuthn relying-party settings to the dashboard origin
+without printing their existing values. Every successful or failed run retains per-service deployment
+receipts for 90 days.
+
+A manual dispatch defaults to the current `main` tip. Selecting an older full SHA additionally requires the
+explicit `allow_non_tip` rollback input, and the workflow still rejects commits that are not ancestors of
+`main`. Customer projects cloned from the public template remain independently owned and are never mutated by
+RustyAuth's repository credentials; operators choose when to adopt a newer pinned release.
+
 ### RustyAuth service
 
 Use the repository root as the source root and `Dockerfile` as the builder. Set:

--- a/railway.control-plane.json
+++ b/railway.control-plane.json
@@ -10,6 +10,7 @@
     "drainingSeconds": 25,
     "healthcheckPath": "/readyz",
     "healthcheckTimeout": 180,
+    "preDeployCommand": ["/usr/local/bin/rustyauth doctor"],
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/railway.dashboard.json
+++ b/railway.dashboard.json
@@ -8,7 +8,7 @@
     "numReplicas": 1,
     "overlapSeconds": 10,
     "drainingSeconds": 10,
-    "healthcheckPath": "/healthz",
+    "healthcheckPath": "/readyz",
     "healthcheckTimeout": 180,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10

--- a/railway.json
+++ b/railway.json
@@ -8,8 +8,9 @@
     "numReplicas": 1,
     "overlapSeconds": 0,
     "drainingSeconds": 25,
-    "healthcheckPath": "/healthz",
+    "healthcheckPath": "/readyz",
     "healthcheckTimeout": 180,
+    "preDeployCommand": ["/usr/local/bin/rustyauth doctor"],
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/railway.realm.json
+++ b/railway.realm.json
@@ -10,6 +10,7 @@
     "drainingSeconds": 25,
     "healthcheckPath": "/readyz",
     "healthcheckTimeout": 180,
+    "preDeployCommand": ["/usr/local/bin/rustyauth doctor"],
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -3,6 +3,7 @@ import {
   matchingDeployment,
   normalizeDigest,
   parseDeployments,
+  pinnedImageReference,
   RailwayDeployment,
   RailwayRunner,
   rolloutRailwayImage,
@@ -11,6 +12,7 @@ import {
 
 const digest = `sha256:${"a".repeat(64)}`;
 const image = "ghcr.io/rusty-auth/rustyauth:main-0123456789abcdef";
+const sourceImage = `ghcr.io/rusty-auth/rustyauth@${digest}`;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -28,7 +30,7 @@ function deployment(id: string, status: string, target = true): RailwayDeploymen
   return {
     id,
     status,
-    meta: target ? { image, imageDigest: digest, serviceManifest: { deploy: policy } } : {
+    meta: target ? { image: sourceImage, imageDigest: digest, serviceManifest: { deploy: policy } } : {
       image: "ghcr.io/rusty-auth/rustyauth:older",
       imageDigest: `sha256:${"b".repeat(64)}`,
     },
@@ -61,10 +63,12 @@ Deno.test("deployment parsing and matching require the exact image and digest", 
     deployment("other", "SUCCESS", false),
     deployment("candidate", "SUCCESS"),
   ]));
-  assertEquals(matchingDeployment(deployments, image, digest)?.id, "candidate");
-  assertEquals(matchingDeployment(deployments, image, digest, new Set(["candidate"])), undefined);
-  assertEquals(matchingDeployment(deployments, image, `sha256:${"c".repeat(64)}`), undefined);
+  assertEquals(matchingDeployment(deployments, sourceImage, digest)?.id, "candidate");
+  assertEquals(matchingDeployment(deployments, sourceImage, digest, new Set(["candidate"])), undefined);
+  assertEquals(matchingDeployment(deployments, sourceImage, `sha256:${"c".repeat(64)}`), undefined);
   assertEquals(normalizeDigest(digest.toUpperCase()), digest);
+  assertEquals(pinnedImageReference(image, digest), sourceImage);
+  assertEquals(pinnedImageReference(`${image}@${digest}`, digest), sourceImage);
   assert(deploymentMatchesProfile(deployments[1], "realm"), "candidate policy did not match");
 });
 
@@ -97,6 +101,7 @@ Deno.test("a historical matching image is not mistaken for the active deployment
     () => Promise.resolve(),
   );
   assertEquals(receipt.deploymentId, "new");
+  assertEquals(receipt.sourceImage, sourceImage);
   assertEquals(mutations, 1);
 });
 
@@ -145,7 +150,55 @@ Deno.test("rollout waits for the exact digest to reach terminal success before h
   assertEquals(receipt.previousDeploymentId, "old");
   assertEquals(healthChecks, 1);
   assert(commands.some((args) => args[0] === "api"), "service update mutation was not invoked");
+  const mutation = commands.find((args) => args[0] === "api");
+  const variablesIndex = mutation?.indexOf("--variables") ?? -1;
+  const variables = JSON.parse(variablesIndex >= 0 ? mutation?.[variablesIndex + 1] ?? "{}" : "{}") as {
+    input?: { source?: { image?: string } };
+  };
+  assertEquals(variables.input?.source?.image, sourceImage);
   assert(commands.filter((args) => args[0] === "deployment").length === 4, "rollout did not poll");
+});
+
+Deno.test("a deployment receipt exists before a failing health check so rollback can restore it", async () => {
+  const receiptPath = await Deno.makeTempFile();
+  const outputs = [
+    JSON.stringify([deployment("old", "SUCCESS", false)]),
+    JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
+  ];
+  const runner: RailwayRunner = () =>
+    Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
+  try {
+    let error = "";
+    try {
+      await rolloutRailwayImage(
+        {
+          project: "project",
+          environment: "production",
+          service: "api",
+          profile: "realm",
+          image,
+          digest,
+          healthUrls: ["https://auth.example.test/readyz"],
+          receipt: receiptPath,
+          timeoutMs: 100,
+          pollMs: 1,
+        },
+        runner,
+        () => Promise.resolve(),
+        () => new Date(0),
+        () => Promise.reject(new Error("synthetic health failure")),
+      );
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+    assert(error.includes("synthetic health failure"), `unexpected error: ${error}`);
+    const receipt = JSON.parse(await Deno.readTextFile(receiptPath)) as Record<string, unknown>;
+    assertEquals(receipt.deploymentId, "new");
+    assertEquals(receipt.healthVerifiedAt, null);
+  } finally {
+    await Deno.remove(receiptPath);
+  }
 });
 
 Deno.test("rollout is idempotent when the exact successful digest is already active", async () => {

--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -1,0 +1,213 @@
+import {
+  deploymentMatchesProfile,
+  matchingDeployment,
+  normalizeDigest,
+  parseDeployments,
+  RailwayDeployment,
+  RailwayRunner,
+  rolloutRailwayImage,
+  serviceUpdateInput,
+} from "./railway-rollout.ts";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const image = "ghcr.io/rusty-auth/rustyauth:main-0123456789abcdef";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function deployment(id: string, status: string, target = true): RailwayDeployment {
+  const policy = serviceUpdateInput("realm", image);
+  delete policy.source;
+  return {
+    id,
+    status,
+    meta: target ? { image, imageDigest: digest, serviceManifest: { deploy: policy } } : {
+      image: "ghcr.io/rusty-auth/rustyauth:older",
+      imageDigest: `sha256:${"b".repeat(64)}`,
+    },
+  };
+}
+
+Deno.test("Railway service profiles preserve the one-writer and readiness policies", () => {
+  assertEquals(serviceUpdateInput("realm", image), {
+    source: { image },
+    healthcheckPath: "/readyz",
+    healthcheckTimeout: 180,
+    numReplicas: 1,
+    overlapSeconds: 0,
+    drainingSeconds: 25,
+    preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
+    restartPolicyType: "ON_FAILURE",
+    restartPolicyMaxRetries: 10,
+  });
+  const dashboard = serviceUpdateInput("dashboard", image);
+  assertEquals(dashboard.numReplicas, 1);
+  assertEquals(dashboard.healthcheckPath, "/readyz");
+  assertEquals(dashboard.overlapSeconds, 10);
+  const sabledb = serviceUpdateInput("sabledb", image);
+  assertEquals(sabledb.restartPolicyType, "ALWAYS");
+  assertEquals(sabledb.numReplicas, 1);
+});
+
+Deno.test("deployment parsing and matching require the exact image and digest", () => {
+  const deployments = parseDeployments(JSON.stringify([
+    deployment("other", "SUCCESS", false),
+    deployment("candidate", "SUCCESS"),
+  ]));
+  assertEquals(matchingDeployment(deployments, image, digest)?.id, "candidate");
+  assertEquals(matchingDeployment(deployments, image, digest, new Set(["candidate"])), undefined);
+  assertEquals(matchingDeployment(deployments, image, `sha256:${"c".repeat(64)}`), undefined);
+  assertEquals(normalizeDigest(digest.toUpperCase()), digest);
+  assert(deploymentMatchesProfile(deployments[1], "realm"), "candidate policy did not match");
+});
+
+Deno.test("a historical matching image is not mistaken for the active deployment", async () => {
+  const outputs = [
+    JSON.stringify([deployment("current", "SUCCESS", false), deployment("historical", "SUCCESS")]),
+    JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify([deployment("new", "SUCCESS"), deployment("current", "SUCCESS", false)]),
+  ];
+  let mutations = 0;
+  const runner: RailwayRunner = (args) => {
+    if (args[0] === "api") mutations++;
+    return Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
+  };
+  const receipt = await rolloutRailwayImage(
+    {
+      project: "project",
+      environment: "production",
+      service: "api",
+      profile: "realm",
+      image,
+      digest,
+      healthUrls: [],
+      timeoutMs: 100,
+      pollMs: 1,
+    },
+    runner,
+    () => Promise.resolve(),
+    () => new Date(0),
+    () => Promise.resolve(),
+  );
+  assertEquals(receipt.deploymentId, "new");
+  assertEquals(mutations, 1);
+});
+
+Deno.test("rollout waits for the exact digest to reach terminal success before health checks", async () => {
+  const outputs = [
+    JSON.stringify([deployment("old", "SUCCESS", false)]),
+    JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify([deployment("queued", "QUEUED"), deployment("old", "SUCCESS", false)]),
+    JSON.stringify([deployment("new", "DEPLOYING"), deployment("old", "SUCCESS", false)]),
+    JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
+  ];
+  const commands: string[][] = [];
+  const runner: RailwayRunner = (args) => {
+    commands.push(args);
+    return Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
+  };
+  let clock = 0;
+  let healthChecks = 0;
+  const receipt = await rolloutRailwayImage(
+    {
+      project: "project",
+      environment: "production",
+      service: "api",
+      profile: "realm",
+      image,
+      digest,
+      healthUrls: ["https://auth.example.test/readyz"],
+      timeoutMs: 5_000,
+      pollMs: 10,
+    },
+    runner,
+    (milliseconds) => {
+      clock += milliseconds;
+      return Promise.resolve();
+    },
+    () => new Date(clock),
+    (urls) => {
+      healthChecks++;
+      assertEquals(urls, ["https://auth.example.test/readyz"]);
+      return Promise.resolve();
+    },
+  );
+
+  assertEquals(receipt.deploymentId, "new");
+  assertEquals(receipt.changed, true);
+  assertEquals(receipt.previousDeploymentId, "old");
+  assertEquals(healthChecks, 1);
+  assert(commands.some((args) => args[0] === "api"), "service update mutation was not invoked");
+  assert(commands.filter((args) => args[0] === "deployment").length === 4, "rollout did not poll");
+});
+
+Deno.test("rollout is idempotent when the exact successful digest is already active", async () => {
+  let calls = 0;
+  const runner: RailwayRunner = () => {
+    calls++;
+    return Promise.resolve({
+      code: 0,
+      stdout: JSON.stringify([deployment("current", "SUCCESS")]),
+      stderr: "",
+    });
+  };
+  const receipt = await rolloutRailwayImage(
+    {
+      project: "project",
+      environment: "production",
+      service: "api",
+      profile: "realm",
+      image,
+      digest,
+      healthUrls: [],
+      timeoutMs: 100,
+      pollMs: 1,
+    },
+    runner,
+    () => Promise.resolve(),
+    () => new Date(0),
+    () => Promise.resolve(),
+  );
+  assertEquals(receipt.changed, false);
+  assertEquals(calls, 1);
+});
+
+Deno.test("rollout fails closed on a terminal failed deployment", async () => {
+  const outputs = [
+    JSON.stringify([deployment("old", "SUCCESS", false)]),
+    JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify([deployment("failed", "FAILED")]),
+  ];
+  const runner: RailwayRunner = () =>
+    Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
+  let error = "";
+  try {
+    await rolloutRailwayImage(
+      {
+        project: "project",
+        environment: "production",
+        service: "api",
+        profile: "realm",
+        image,
+        digest,
+        healthUrls: [],
+        timeoutMs: 100,
+        pollMs: 1,
+      },
+      runner,
+      () => Promise.resolve(),
+      () => new Date(0),
+      () => Promise.resolve(),
+    );
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : String(caught);
+  }
+  assert(error.includes("ended in FAILED"), `unexpected error: ${error}`);
+});

--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -233,6 +233,7 @@ Deno.test("rollout is idempotent when the exact successful digest is already act
 });
 
 Deno.test("rollout fails closed on a terminal failed deployment", async () => {
+  const receiptPath = await Deno.makeTempFile();
   const outputs = [
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
@@ -240,27 +241,37 @@ Deno.test("rollout fails closed on a terminal failed deployment", async () => {
   ];
   const runner: RailwayRunner = () =>
     Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
-  let error = "";
   try {
-    await rolloutRailwayImage(
-      {
-        project: "project",
-        environment: "production",
-        service: "api",
-        profile: "realm",
-        image,
-        digest,
-        healthUrls: [],
-        timeoutMs: 100,
-        pollMs: 1,
-      },
-      runner,
-      () => Promise.resolve(),
-      () => new Date(0),
-      () => Promise.resolve(),
-    );
-  } catch (caught) {
-    error = caught instanceof Error ? caught.message : String(caught);
+    let error = "";
+    try {
+      await rolloutRailwayImage(
+        {
+          project: "project",
+          environment: "production",
+          service: "api",
+          profile: "realm",
+          image,
+          digest,
+          healthUrls: [],
+          receipt: receiptPath,
+          timeoutMs: 100,
+          pollMs: 1,
+        },
+        runner,
+        () => Promise.resolve(),
+        () => new Date(0),
+        () => Promise.resolve(),
+      );
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+    assert(error.includes("ended in FAILED"), `unexpected error: ${error}`);
+    const receipt = JSON.parse(await Deno.readTextFile(receiptPath)) as Record<string, unknown>;
+    assertEquals(receipt.changed, true);
+    assertEquals(receipt.status, "PENDING");
+    assertEquals(receipt.deploymentId, null);
+    assertEquals(receipt.previousDeploymentId, "old");
+  } finally {
+    await Deno.remove(receiptPath);
   }
-  assert(error.includes("ended in FAILED"), `unexpected error: ${error}`);
 });

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -42,14 +42,14 @@ export interface RailwayRolloutReceipt {
   previousDeploymentId: string | null;
   previousImage: string | null;
   previousDigest: string | null;
-  deploymentId: string;
+  deploymentId: string | null;
   image: string;
   sourceImage: string;
   digest: string;
-  status: "SUCCESS";
+  status: "PENDING" | "SUCCESS";
   changed: boolean;
   healthUrls: string[];
-  deploymentSucceededAt: string;
+  deploymentSucceededAt: string | null;
   healthVerifiedAt: string | null;
 }
 
@@ -285,8 +285,31 @@ export async function rolloutRailwayImage(
   const previous = baseline[0];
   const current = previous && matchingDeployment([previous], sourceImage, digest);
 
+  const receipt: RailwayRolloutReceipt = {
+    project: options.project,
+    environment: options.environment,
+    service: options.service,
+    profile: options.profile,
+    previousDeploymentId: previous?.id ?? null,
+    previousImage: previous?.meta?.image ?? null,
+    previousDigest: previous?.meta?.imageDigest ?? null,
+    deploymentId: null,
+    image: options.image,
+    sourceImage,
+    digest,
+    status: "PENDING",
+    changed: false,
+    healthUrls: options.healthUrls,
+    deploymentSucceededAt: null,
+    healthVerifiedAt: null,
+  };
+  const writeReceipt = async (): Promise<void> => {
+    if (options.receipt) {
+      await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
+    }
+  };
+
   let deployment: RailwayDeployment | undefined;
-  let changed = false;
   if (current?.status === "SUCCESS" && deploymentMatchesProfile(current, options.profile)) {
     deployment = current;
   } else {
@@ -297,7 +320,8 @@ export async function rolloutRailwayImage(
     if (update.errors?.length || update.data?.serviceInstanceUpdate !== true) {
       fail("Railway rejected the service image/configuration update");
     }
-    changed = true;
+    receipt.changed = true;
+    await writeReceipt();
 
     const baselineIds = new Set(baseline.map((existing) => existing.id));
     const deadline = now().getTime() + options.timeoutMs;
@@ -330,33 +354,13 @@ export async function rolloutRailwayImage(
   }
 
   if (!deployment) fail("Railway rollout completed without a deployment");
-  const receipt: RailwayRolloutReceipt = {
-    project: options.project,
-    environment: options.environment,
-    service: options.service,
-    profile: options.profile,
-    previousDeploymentId: previous?.id ?? null,
-    previousImage: previous?.meta?.image ?? null,
-    previousDigest: previous?.meta?.imageDigest ?? null,
-    deploymentId: deployment.id,
-    image: options.image,
-    sourceImage,
-    digest,
-    status: "SUCCESS",
-    changed,
-    healthUrls: options.healthUrls,
-    deploymentSucceededAt: now().toISOString(),
-    healthVerifiedAt: null,
-  };
-
-  if (options.receipt) {
-    await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
-  }
+  receipt.deploymentId = deployment.id;
+  receipt.status = "SUCCESS";
+  receipt.deploymentSucceededAt = now().toISOString();
+  await writeReceipt();
   await healthCheck(options.healthUrls);
   receipt.healthVerifiedAt = now().toISOString();
-  if (options.receipt) {
-    await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
-  }
+  await writeReceipt();
   return receipt;
 }
 

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -1,0 +1,413 @@
+interface RailwayCommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type RailwayRunner = (args: string[]) => Promise<RailwayCommandResult>;
+
+export interface RailwayDeployment {
+  id: string;
+  status: string;
+  createdAt?: string;
+  meta?: {
+    image?: string;
+    imageDigest?: string;
+    serviceManifest?: {
+      deploy?: Record<string, unknown>;
+    };
+  };
+}
+
+export type RailwayServiceProfile = "realm" | "dashboard" | "sabledb";
+
+export interface RailwayRolloutOptions {
+  project: string;
+  environment: string;
+  service: string;
+  profile: RailwayServiceProfile;
+  image: string;
+  digest: string;
+  healthUrls: string[];
+  receipt?: string;
+  timeoutMs: number;
+  pollMs: number;
+}
+
+export interface RailwayRolloutReceipt {
+  project: string;
+  environment: string;
+  service: string;
+  profile: RailwayServiceProfile;
+  previousDeploymentId: string | null;
+  previousImage: string | null;
+  previousDigest: string | null;
+  deploymentId: string;
+  image: string;
+  digest: string;
+  status: "SUCCESS";
+  changed: boolean;
+  healthUrls: string[];
+  verifiedAt: string;
+}
+
+const UPDATE_SERVICE_MUTATION = `
+mutation UpdateService(
+  $serviceId: String!
+  $environmentId: String!
+  $input: ServiceInstanceUpdateInput!
+) {
+  serviceInstanceUpdate(
+    serviceId: $serviceId
+    environmentId: $environmentId
+    input: $input
+  )
+}
+`.trim();
+
+const pendingStatuses = new Set([
+  "BUILDING",
+  "CREATING",
+  "DEPLOYING",
+  "INITIALIZING",
+  "QUEUED",
+  "WAITING",
+]);
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value?.trim()) fail(`${name} is required`);
+  return value.trim();
+}
+
+function positiveInteger(value: string | undefined, name: string, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) fail(`${name} must be a positive integer`);
+  return parsed;
+}
+
+export function normalizeDigest(value: string): string {
+  const digest = value.trim().toLowerCase();
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    fail(`digest must be a sha256 digest, received ${JSON.stringify(value)}`);
+  }
+  return digest;
+}
+
+export function serviceUpdateInput(
+  profile: RailwayServiceProfile,
+  image: string,
+): Record<string, unknown> {
+  const source = { image };
+  switch (profile) {
+    case "realm":
+      return {
+        source,
+        healthcheckPath: "/readyz",
+        healthcheckTimeout: 180,
+        numReplicas: 1,
+        overlapSeconds: 0,
+        drainingSeconds: 25,
+        preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
+        restartPolicyType: "ON_FAILURE",
+        restartPolicyMaxRetries: 10,
+      };
+    case "dashboard":
+      return {
+        source,
+        healthcheckPath: "/readyz",
+        healthcheckTimeout: 180,
+        numReplicas: 1,
+        overlapSeconds: 10,
+        drainingSeconds: 10,
+        restartPolicyType: "ON_FAILURE",
+        restartPolicyMaxRetries: 10,
+      };
+    case "sabledb":
+      return {
+        source,
+        numReplicas: 1,
+        overlapSeconds: 0,
+        restartPolicyType: "ALWAYS",
+      };
+  }
+}
+
+export function parseDeployments(raw: string): RailwayDeployment[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    fail("Railway deployment list did not return valid JSON");
+  }
+  if (!Array.isArray(parsed)) fail("Railway deployment list was not an array");
+  return parsed.map((deployment, index) => {
+    if (!deployment || typeof deployment !== "object") {
+      fail(`Railway deployment ${index} was not an object`);
+    }
+    const record = deployment as Record<string, unknown>;
+    if (typeof record.id !== "string" || typeof record.status !== "string") {
+      fail(`Railway deployment ${index} is missing id or status`);
+    }
+    return deployment as RailwayDeployment;
+  });
+}
+
+export function matchingDeployment(
+  deployments: RailwayDeployment[],
+  image: string,
+  digest: string,
+  excludedIds: ReadonlySet<string> = new Set(),
+): RailwayDeployment | undefined {
+  return deployments.find((deployment) =>
+    !excludedIds.has(deployment.id) &&
+    deployment.meta?.image === image && deployment.meta?.imageDigest?.toLowerCase() === digest
+  );
+}
+
+export function deploymentMatchesProfile(
+  deployment: RailwayDeployment,
+  profile: RailwayServiceProfile,
+): boolean {
+  const actual = deployment.meta?.serviceManifest?.deploy;
+  if (!actual) return false;
+  const expected = serviceUpdateInput(profile, deployment.meta?.image ?? "");
+  for (const [key, value] of Object.entries(expected)) {
+    if (key === "source") continue;
+    if (JSON.stringify(actual[key]) !== JSON.stringify(value)) return false;
+  }
+  return true;
+}
+
+function commandError(args: string[], result: RailwayCommandResult): Error {
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+  return new Error(`railway ${args[0]} failed: ${detail}`);
+}
+
+async function runJson(
+  runner: RailwayRunner,
+  args: string[],
+): Promise<string> {
+  const result = await runner(args);
+  if (result.code !== 0) throw commandError(args, result);
+  return result.stdout;
+}
+
+function deploymentListArgs(options: RailwayRolloutOptions): string[] {
+  return [
+    "deployment",
+    "list",
+    "--project",
+    options.project,
+    "--environment",
+    options.environment,
+    "--service",
+    options.service,
+    "--limit",
+    "20",
+    "--json",
+  ];
+}
+
+function updateArgs(options: RailwayRolloutOptions): string[] {
+  const variables = {
+    serviceId: options.service,
+    environmentId: options.environment,
+    input: serviceUpdateInput(options.profile, options.image),
+  };
+  return [
+    "api",
+    UPDATE_SERVICE_MUTATION,
+    "--variables",
+    JSON.stringify(variables),
+    "--compact",
+  ];
+}
+
+async function verifyHealth(urls: string[]): Promise<void> {
+  for (const url of urls) {
+    let lastFailure = "no response";
+    for (let attempt = 1; attempt <= 12; attempt++) {
+      try {
+        const response = await fetch(url, {
+          redirect: "error",
+          signal: AbortSignal.timeout(15_000),
+        });
+        const body = await response.text();
+        if (!response.ok) {
+          lastFailure = `HTTP ${response.status}`;
+        } else {
+          const status = (JSON.parse(body) as Record<string, unknown>).status;
+          if (status === "ok" || status === "ready") {
+            lastFailure = "";
+            break;
+          }
+          lastFailure = `unexpected status ${JSON.stringify(status)}`;
+        }
+      } catch (error) {
+        lastFailure = error instanceof Error ? error.message : String(error);
+      }
+      if (attempt < 12) await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    if (lastFailure) fail(`health verification failed for ${url}: ${lastFailure}`);
+  }
+}
+
+export async function rolloutRailwayImage(
+  options: RailwayRolloutOptions,
+  runner: RailwayRunner,
+  sleep: (milliseconds: number) => Promise<void> = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  now: () => Date = () => new Date(),
+  healthCheck: (urls: string[]) => Promise<void> = verifyHealth,
+): Promise<RailwayRolloutReceipt> {
+  const digest = normalizeDigest(options.digest);
+  const baseline = parseDeployments(await runJson(runner, deploymentListArgs(options)));
+  const previous = baseline[0];
+  const current = previous && matchingDeployment([previous], options.image, digest);
+
+  let deployment: RailwayDeployment | undefined;
+  let changed = false;
+  if (current?.status === "SUCCESS" && deploymentMatchesProfile(current, options.profile)) {
+    deployment = current;
+  } else {
+    const update = JSON.parse(await runJson(runner, updateArgs(options))) as {
+      data?: { serviceInstanceUpdate?: boolean };
+      errors?: unknown[];
+    };
+    if (update.errors?.length || update.data?.serviceInstanceUpdate !== true) {
+      fail("Railway rejected the service image/configuration update");
+    }
+    changed = true;
+
+    const baselineIds = new Set(baseline.map((existing) => existing.id));
+    const deadline = now().getTime() + options.timeoutMs;
+    let latestObserved = "no deployment";
+    while (now().getTime() < deadline) {
+      const deployments = parseDeployments(await runJson(runner, deploymentListArgs(options)));
+      const candidate = matchingDeployment(deployments, options.image, digest, baselineIds);
+      if (!candidate) {
+        latestObserved = deployments[0] ? `${deployments[0].id} (${deployments[0].status})` : "no deployment";
+        await sleep(options.pollMs);
+        continue;
+      }
+
+      latestObserved = `${candidate.id} (${candidate.status})`;
+      if (candidate.status === "SUCCESS") {
+        if (!deploymentMatchesProfile(candidate, options.profile)) {
+          fail(`Railway deployment ${candidate.id} succeeded with an unexpected service policy`);
+        }
+        deployment = candidate;
+        break;
+      }
+      if (!pendingStatuses.has(candidate.status)) {
+        fail(`Railway deployment ${candidate.id} ended in ${candidate.status}`);
+      }
+      await sleep(options.pollMs);
+    }
+    if (!deployment) {
+      fail(`Railway deployment timed out after ${options.timeoutMs}ms; latest was ${latestObserved}`);
+    }
+  }
+
+  if (!deployment) fail("Railway rollout completed without a deployment");
+  await healthCheck(options.healthUrls);
+  const receipt: RailwayRolloutReceipt = {
+    project: options.project,
+    environment: options.environment,
+    service: options.service,
+    profile: options.profile,
+    previousDeploymentId: previous?.id ?? null,
+    previousImage: previous?.meta?.image ?? null,
+    previousDigest: previous?.meta?.imageDigest ?? null,
+    deploymentId: deployment.id,
+    image: options.image,
+    digest,
+    status: "SUCCESS",
+    changed,
+    healthUrls: options.healthUrls,
+    verifiedAt: now().toISOString(),
+  };
+
+  if (options.receipt) {
+    await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
+  }
+  return receipt;
+}
+
+function parseOptions(args: string[]): RailwayRolloutOptions {
+  const values = new Map<string, string[]>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) fail(`invalid argument near ${flag ?? "end"}`);
+    const existing = values.get(flag) ?? [];
+    existing.push(value);
+    values.set(flag, existing);
+  }
+  const profile = required(values.get("--profile")?.[0], "--profile") as RailwayServiceProfile;
+  if (!(["realm", "dashboard", "sabledb"] as string[]).includes(profile)) {
+    fail(`--profile must be realm, dashboard or sabledb`);
+  }
+  const healthUrls = values.get("--health-url") ?? [];
+  for (const url of healthUrls) {
+    if (!url.startsWith("https://")) fail(`--health-url must use https: ${url}`);
+  }
+  return {
+    project: required(values.get("--project")?.[0], "--project"),
+    environment: required(values.get("--environment")?.[0], "--environment"),
+    service: required(values.get("--service")?.[0], "--service"),
+    profile,
+    image: required(values.get("--image")?.[0], "--image"),
+    digest: required(values.get("--digest")?.[0], "--digest"),
+    healthUrls,
+    receipt: values.get("--receipt")?.[0],
+    timeoutMs: positiveInteger(values.get("--timeout-ms")?.[0], "--timeout-ms", 20 * 60 * 1_000),
+    pollMs: positiveInteger(values.get("--poll-ms")?.[0], "--poll-ms", 10_000),
+  };
+}
+
+function commandRunner(binary: string): RailwayRunner {
+  return async (args) => {
+    const command = new Deno.Command(binary, {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+      env: {
+        RAILWAY_CALLER: "workflow:rustyauth-main-cd",
+        RAILWAY_AGENT_SESSION: Deno.env.get("RAILWAY_AGENT_SESSION") ??
+          `github-${Deno.env.get("GITHUB_RUN_ID") ?? "local"}`,
+      },
+    });
+    const output = await command.output();
+    return {
+      code: output.code,
+      stdout: new TextDecoder().decode(output.stdout),
+      stderr: new TextDecoder().decode(output.stderr),
+    };
+  };
+}
+
+if (import.meta.main) {
+  try {
+    if (!Deno.env.get("RAILWAY_TOKEN") && !Deno.env.get("RAILWAY_API_TOKEN")) {
+      fail("RAILWAY_TOKEN or RAILWAY_API_TOKEN is required");
+    }
+    const options = parseOptions(Deno.args);
+    const receipt = await rolloutRailwayImage(
+      options,
+      commandRunner(Deno.env.get("RAILWAY_BIN") ?? "railway"),
+    );
+    console.log(
+      `${receipt.service} is ${receipt.status} on ${receipt.image}@${receipt.digest} ` +
+        `(${receipt.changed ? "deployed" : "already current"})`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    Deno.exit(1);
+  }
+}

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -44,11 +44,13 @@ export interface RailwayRolloutReceipt {
   previousDigest: string | null;
   deploymentId: string;
   image: string;
+  sourceImage: string;
   digest: string;
   status: "SUCCESS";
   changed: boolean;
   healthUrls: string[];
-  verifiedAt: string;
+  deploymentSucceededAt: string;
+  healthVerifiedAt: string | null;
 }
 
 const UPDATE_SERVICE_MUTATION = `
@@ -96,6 +98,18 @@ export function normalizeDigest(value: string): string {
     fail(`digest must be a sha256 digest, received ${JSON.stringify(value)}`);
   }
   return digest;
+}
+
+export function pinnedImageReference(image: string, digest: string): string {
+  const normalizedDigest = normalizeDigest(digest);
+  const withoutDigest = image.trim().split("@", 1)[0];
+  const lastSlash = withoutDigest.lastIndexOf("/");
+  const lastColon = withoutDigest.lastIndexOf(":");
+  const repository = lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+  if (!repository || !repository.includes("/") || /\s/.test(repository)) {
+    fail(`image must include a registry repository, received ${JSON.stringify(image)}`);
+  }
+  return `${repository}@${normalizedDigest}`;
 }
 
 export function serviceUpdateInput(
@@ -213,11 +227,11 @@ function deploymentListArgs(options: RailwayRolloutOptions): string[] {
   ];
 }
 
-function updateArgs(options: RailwayRolloutOptions): string[] {
+function updateArgs(options: RailwayRolloutOptions, sourceImage: string): string[] {
   const variables = {
     serviceId: options.service,
     environmentId: options.environment,
-    input: serviceUpdateInput(options.profile, options.image),
+    input: serviceUpdateInput(options.profile, sourceImage),
   };
   return [
     "api",
@@ -266,16 +280,17 @@ export async function rolloutRailwayImage(
   healthCheck: (urls: string[]) => Promise<void> = verifyHealth,
 ): Promise<RailwayRolloutReceipt> {
   const digest = normalizeDigest(options.digest);
+  const sourceImage = pinnedImageReference(options.image, digest);
   const baseline = parseDeployments(await runJson(runner, deploymentListArgs(options)));
   const previous = baseline[0];
-  const current = previous && matchingDeployment([previous], options.image, digest);
+  const current = previous && matchingDeployment([previous], sourceImage, digest);
 
   let deployment: RailwayDeployment | undefined;
   let changed = false;
   if (current?.status === "SUCCESS" && deploymentMatchesProfile(current, options.profile)) {
     deployment = current;
   } else {
-    const update = JSON.parse(await runJson(runner, updateArgs(options))) as {
+    const update = JSON.parse(await runJson(runner, updateArgs(options, sourceImage))) as {
       data?: { serviceInstanceUpdate?: boolean };
       errors?: unknown[];
     };
@@ -289,7 +304,7 @@ export async function rolloutRailwayImage(
     let latestObserved = "no deployment";
     while (now().getTime() < deadline) {
       const deployments = parseDeployments(await runJson(runner, deploymentListArgs(options)));
-      const candidate = matchingDeployment(deployments, options.image, digest, baselineIds);
+      const candidate = matchingDeployment(deployments, sourceImage, digest, baselineIds);
       if (!candidate) {
         latestObserved = deployments[0] ? `${deployments[0].id} (${deployments[0].status})` : "no deployment";
         await sleep(options.pollMs);
@@ -315,7 +330,6 @@ export async function rolloutRailwayImage(
   }
 
   if (!deployment) fail("Railway rollout completed without a deployment");
-  await healthCheck(options.healthUrls);
   const receipt: RailwayRolloutReceipt = {
     project: options.project,
     environment: options.environment,
@@ -326,13 +340,20 @@ export async function rolloutRailwayImage(
     previousDigest: previous?.meta?.imageDigest ?? null,
     deploymentId: deployment.id,
     image: options.image,
+    sourceImage,
     digest,
     status: "SUCCESS",
     changed,
     healthUrls: options.healthUrls,
-    verifiedAt: now().toISOString(),
+    deploymentSucceededAt: now().toISOString(),
+    healthVerifiedAt: null,
   };
 
+  if (options.receipt) {
+    await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
+  }
+  await healthCheck(options.healthUrls);
+  receipt.healthVerifiedAt = now().toISOString();
   if (options.receipt) {
     await Deno.writeTextFile(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
   }

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -1,0 +1,63 @@
+const workflow = await Deno.readTextFile(".github/workflows/railway-production.yml");
+const rollout = await Deno.readTextFile("scripts/railway-rollout.ts");
+
+function assertIncludes(source: string, required: string): void {
+  if (!source.includes(required)) throw new Error(`missing ${JSON.stringify(required)}`);
+}
+
+function assertOrdered(source: string, values: string[]): void {
+  let position = -1;
+  for (const value of values) {
+    const next = source.indexOf(value, position + 1);
+    if (next === -1) throw new Error(`missing ordered value ${JSON.stringify(value)}`);
+    position = next;
+  }
+}
+
+Deno.test("Railway automatic deployments follow successful current-main CI only", () => {
+  for (
+    const required of [
+      "workflow_run:",
+      "workflows: [CI]",
+      "branches: [main]",
+      "github.event.workflow_run.conclusion == 'success'",
+      "git merge-base --is-ancestor",
+      "Skipping stale successful CI result",
+      "group: railway-production",
+      "cancel-in-progress: false",
+      "RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}",
+    ]
+  ) assertIncludes(workflow, required);
+});
+
+Deno.test("Railway candidates are immutable, signed and digest-verified", () => {
+  for (
+    const required of [
+      "ghcr.io/rusty-auth/rustyauth:main-${{ needs.prepare.outputs.sha }}",
+      "ghcr.io/rusty-auth/dashboard:main-${{ needs.prepare.outputs.sha }}",
+      "ghcr.io/rusty-auth/sabledb:main-${{ needs.prepare.outputs.sha }}",
+      "provenance: mode=max",
+      "sbom: true",
+      "cosign sign --yes",
+      "matchingDeployment(deployments, options.image, digest, baselineIds)",
+      'candidate.status === "SUCCESS"',
+    ]
+  ) assertIncludes(workflow + rollout, required);
+  if (/tags:.*:latest/.test(workflow)) {
+    throw new Error("production deployment must not use a mutable latest tag");
+  }
+});
+
+Deno.test("Railway rollout is serialized across every stateful boundary", () => {
+  assertOrdered(workflow, [
+    "name: Deploy realm API",
+    "--profile realm",
+    "name: Deploy dashboard",
+    "--profile dashboard",
+    "name: Deploy private SableDB",
+    "--profile sabledb",
+  ]);
+  for (const required of ["/healthz", "/readyz", "retention-days: 90"]) {
+    assertIncludes(workflow, required);
+  }
+});

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -39,7 +39,8 @@ Deno.test("Railway candidates are immutable, signed and digest-verified", () => 
       "provenance: mode=max",
       "sbom: true",
       "cosign sign --yes",
-      "matchingDeployment(deployments, options.image, digest, baselineIds)",
+      "matchingDeployment(deployments, sourceImage, digest, baselineIds)",
+      "pinnedImageReference(options.image, digest)",
       'candidate.status === "SUCCESS"',
     ]
   ) assertIncludes(workflow + rollout, required);
@@ -60,4 +61,16 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
   for (const required of ["/healthz", "/readyz", "retention-days: 90"]) {
     assertIncludes(workflow, required);
   }
+});
+
+Deno.test("a partial Railway rollout restores services and browser origin in reverse order", () => {
+  assertIncludes(workflow, "name: Restore the previous Railway deployment set");
+  assertOrdered(workflow, [
+    'rollback_service "${RUNNER_TEMP}/railway-receipts/sabledb.json"',
+    'rollback_service "${RUNNER_TEMP}/railway-receipts/dashboard.json"',
+    '"AUTH_ISSUER=${previous_issuer}"',
+    'rollback_service "${RUNNER_TEMP}/railway-receipts/api.json"',
+  ]);
+  assertIncludes(workflow, "railway down");
+  assertIncludes(rollout, "healthVerifiedAt: null");
 });


### PR DESCRIPTION
## What changed

- publish signed, SBOM/provenance-enabled API, dashboard and SableDB images for the successful current `main` commit
- roll the maintained Railway production/template project forward in a serialized API → dashboard → SableDB sequence
- require the exact Railway image digest, terminal `SUCCESS`, live health/readiness checks and retained deployment receipts
- add an explicit main-ancestor rollback path and reject stale automatic CI completions
- align Railway config-as-code with readiness health checks and target-image `rustyauth doctor` pre-deploy qualification
- add unit and policy tests for idempotency, history handling, failure states, workflow gating and immutable images

## Why

The maintained Railway project was still pinned to old two-service template images. Merges to `main` should update the release canary automatically after CI rather than depend on manual image replacement.

## Validation

- `deno task check`
- `deno task test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml`
- Railway configuration JSON validated against the current Railway schema

The `railway-production` GitHub environment is restricted to `main`; its workspace-scoped Railway token and non-secret service IDs/URLs are configured. The missing stateless dashboard service and domain have been provisioned without touching the existing SableDB volume.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an automated, digest-pinned Railway production release pipeline with signed container publication, serialized service rollout, health verification, receipts, and reverse rollback.

- Publishes API, dashboard, and SableDB images for verified `main` commits.
- Pins Railway mutations to image digests and verifies terminal deployment state and readiness.
- Captures previous deployment and browser-origin state for rollback.
- Adds Railway configuration, rollout tests, workflow policy tests, and deployment documentation.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because cancelling an in-progress production rollout can bypass restoration and leave a mixed deployment.

The digest pinning and receipt timing issues reported previously are corrected, but the rollback step runs only for failed jobs; cancellation after configuration or service mutation can therefore leave production partially updated.

**Files Needing Attention:** .github/workflows/railway-production.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/railway-production.yml | Adds the end-to-end production workflow and reverse rollback, but cancellation can bypass restoration after production mutations. |
| scripts/railway-rollout.ts | Implements digest-pinned Railway mutations, exact deployment matching, early rollback receipts, profile checks, and health verification. |
| scripts/railway-rollout.test.ts | Exercises immutable image mutation, deployment-history handling, terminal states, receipts, idempotency, and health checks. |
| scripts/railway-workflow.test.ts | Adds policy checks for workflow gating, immutable images, signatures, rollback structure, and retained receipts. |
| railway.json | Changes the API health check to readiness and adds target-image doctor qualification. |
| railway.dashboard.json | Changes dashboard deployment health checks from liveness to readiness. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CI
  participant Workflow
  participant API
  participant Dashboard
  participant SableDB
  CI->>Workflow: Successful current main commit
  Workflow->>API: Capture origins and deploy digest
  API-->>Workflow: SUCCESS and ready
  Workflow->>Dashboard: Deploy digest
  Dashboard-->>Workflow: SUCCESS and ready
  Workflow->>SableDB: Deploy digest
  SableDB-->>Workflow: SUCCESS and dependencies ready
  alt ordinary failure
    Workflow->>SableDB: Restore previous deployment
    Workflow->>Dashboard: Restore previous deployment
    Workflow->>API: Restore origins and deployment
  else workflow cancellation
    Note over Workflow,API: failure()-gated restoration is skipped
  end
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Fautomate-railway-main-deployments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fautomate-railway-main-deployments%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A318%0A**Cancellation%20bypasses%20release%20rollback**%0A%0AWhen%20an%20operator%20cancels%20the%20deploy%20job%20after%20the%20browser-origin%20variables%20or%20a%20service%20has%20been%20updated%2C%20%60if%3A%20failure%28%29%60%20skips%20the%20restoration%20step%20because%20the%20job%20is%20cancelled%20rather%20than%20failed%2C%20leaving%20production%20with%20changed%20origin%20configuration%20or%20a%20mixture%20of%20old%20and%20new%20service%20images.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=25&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A318%0A**Cancellation%20bypasses%20release%20rollback**%0A%0AWhen%20an%20operator%20cancels%20the%20deploy%20job%20after%20the%20browser-origin%20variables%20or%20a%20service%20has%20been%20updated%2C%20%60if%3A%20failure%28%29%60%20skips%20the%20restoration%20step%20because%20the%20job%20is%20cancelled%20rather%20than%20failed%2C%20leaving%20production%20with%20changed%20origin%20configuration%20or%20a%20mixture%20of%20old%20and%20new%20service%20images.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=25&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/railway-production.yml:318
**Cancellation bypasses release rollback**

When an operator cancels the deploy job after the browser-origin variables or a service has been updated, `if: failure()` skips the restoration step because the job is cancelled rather than failed, leaving production with changed origin configuration or a mixture of old and new service images.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: persist rollback intent before deplo..."](https://github.com/rusty-auth/rustyauth/commit/32de655afbe40376f8ac6295020da609c7216b7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51601921)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->