### PR TITLE
ci: fix pinned Railway CLI version

### DIFF
--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -214,6 +214,7 @@ jobs:
       RAILWAY_API_URL: ${{ vars.RAILWAY_API_URL }}
       RAILWAY_DASHBOARD_URL: ${{ vars.RAILWAY_DASHBOARD_URL }}
       RAILWAY_AGENT_SESSION: github-${{ github.run_id }}-${{ github.run_attempt }}
+      RAILWAY_CLI_VERSION: 5.31.1
       RELEASE_SHA: ${{ needs.prepare.outputs.sha }}
       API_DIGEST: ${{ needs.publish-api.outputs.digest }}
       DASHBOARD_DIGEST: ${{ needs.publish-dashboard.outputs.digest }}
@@ -225,8 +226,10 @@ jobs:
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
         with:
           deno-version: 2.9.3
+      - name: Verify pinned Railway CLI package
+        run: test "$(npm view "@railway/cli@${RAILWAY_CLI_VERSION}" version)" = "${RAILWAY_CLI_VERSION}"
       - name: Install pinned Railway CLI
-        run: npm install --global @railway/cli@5.31.0
+        run: npm install --global "@railway/cli@${RAILWAY_CLI_VERSION}"
       - name: Validate deployment target
         run: |
           required=(


### PR DESCRIPTION
## Summary
- pin Railway CLI to the published 5.31.1 npm release
- verify the pinned package exists before installation

## Validation
- npm registry version preflight
- actionlint v1.7.12
- deno task railway:test (11 passed)
- deno task check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs the production deployment workflow by pinning Railway CLI 5.31.1 in a shared job-level variable and checking its availability before installation.
- Adds `RAILWAY_CLI_VERSION` to the deployment job environment.
- Adds an npm registry preflight for the pinned package.
- Uses the shared version variable during global installation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking issue identified in the workflow change.

The deployment job exposes the pinned version to both new commands, uses consistent package coordinates and registry configuration, and fails early if the package cannot be resolved.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/railway-production.yml | Centralizes the Railway CLI version, verifies the package before installation, and consistently installs that exact version; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: fix pinned Railway CLI version"](https://github.com/rusty-auth/rustyauth/commit/0229fd69850466b768f9ec87218ceb7f22358264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51608674)</sub>

<!-- /greptile_comment -->