### PR TITLE
ci: make release checks change-aware

### DIFF
--- a/.github/workflows/assurance.yml
+++ b/.github/workflows/assurance.yml
@@ -1,0 +1,213 @@
+name: Continuous assurance
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Assurance follows main and is intentionally independent of the release gate.
+# Only the newest main revision needs the expensive qualification pass.
+concurrency:
+  group: assurance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build_mode: none
+          - language: javascript-typescript
+            build_mode: none
+          - language: rust
+            build_mode: none
+          - language: go
+            build_mode: autobuild
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build_mode }}
+          dependency-caching: true
+      - name: Analyze
+        uses: github/codeql-action/analyze@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  rust-dependencies:
+    name: Rust dependency assurance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Every advisory ignore is dated and unexpired
+        run: |
+          test -f deny.toml || { echo "::error::deny.toml is missing"; exit 1; }
+          ignores="$(grep -c '{ *id *= *"RUSTSEC' deny.toml || true)"
+          dated="$(grep -c '# expires: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' deny.toml || true)"
+          if [[ "${ignores}" -ne "${dated}" ]]; then
+            echo "::error file=deny.toml::${ignores} advisory ignores but ${dated} '# expires:' comments; every ignore needs one"
+            exit 1
+          fi
+          today="$(date -u +%F)"
+          status=0
+          while IFS= read -r expiry; do
+            if [[ "${expiry}" < "${today}" ]]; then
+              echo "::error file=deny.toml::an advisory ignore expired on ${expiry}"
+              status=1
+            fi
+          done < <(sed -n 's/.*# expires: \([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\).*/\1/p' deny.toml)
+          exit "${status}"
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          rust-version: 1.94.1
+          command: check advisories bans licenses sources
+          arguments: --all-features --locked
+      - name: Audit independently locked Rust dependency graphs
+        run: |
+          cargo install cargo-audit --version 0.22.2 --locked
+          cargo audit --file console/Cargo.lock
+          cargo audit --file sabledb/Cargo.lock
+
+  go-vulnerabilities:
+    name: Go vulnerability reachability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: infra/cloudflare
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: infra/cloudflare/go.mod
+          cache-dependency-path: infra/cloudflare/go.sum
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          "$(go env GOPATH)/bin/govulncheck" ./...
+
+  image-security:
+    name: Container scan (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: API
+            file: Dockerfile
+            tag: rustyauth:assurance
+            cache_scope: rustyauth-image
+          - name: dashboard
+            file: Dockerfile.dashboard
+            tag: rustyauth-dashboard:assurance
+            cache_scope: dashboard-image
+          - name: SableDB
+            file: sabledb/Dockerfile
+            tag: rustyauth-sabledb:assurance
+            cache_scope: sabledb-image
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build ${{ matrix.name }} through the shared layer cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          load: true
+          tags: ${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=max
+      - name: Install checksum-pinned image scanner
+        run: ./scripts/install-trivy.sh "${RUNNER_TEMP}/trivy"
+      - name: Reject HIGH or CRITICAL image findings
+        run: >-
+          "${RUNNER_TEMP}/trivy/trivy" image --quiet --scanners vuln
+          --severity HIGH,CRITICAL --exit-code 1 "${{ matrix.tag }}"
+
+  runtime-qualification:
+    name: Runtime qualification (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [backup, fleet, analytics]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          key: assurance-${{ matrix.suite }}
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build the shared SableDB test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./sabledb/Dockerfile
+          load: true
+          tags: rustyauth-sabledb:ci
+          cache-from: type=gha,scope=sabledb-image
+          cache-to: type=gha,scope=sabledb-image,mode=max
+      - name: Start isolated integration services
+        run: >-
+          docker compose -f compose.integration.yaml up -d --wait
+          source-sabledb destination-sabledb minio greptimedb
+      - name: Create the private integration bucket
+        run: docker compose -f compose.integration.yaml run --rm minio-init
+      - name: Backup, restore and shared-state qualification
+        if: matrix.suite == 'backup'
+        env:
+          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
+          RUSTYAUTH_TEST_DESTINATION_SABLEDB_URL: redis://127.0.0.1:16380
+          RUSTYAUTH_TEST_S3_ENDPOINT: http://127.0.0.1:19000
+          RUSTYAUTH_TEST_S3_BUCKET: rustyauth-integration
+          RUSTYAUTH_TEST_S3_ACCESS_KEY: rustyauth-test
+          RUSTYAUTH_TEST_S3_SECRET_KEY: rustyauth-test-secret
+        run: |
+          cargo test --locked --test integration_tests clean_room_backup_restore_and_rotation -- --ignored --exact --nocapture
+          cargo test --locked --lib store::live_store_tests::writer_lease_renews_on_pinned_sabledb_and_fences_a_replaced_owner -- --ignored --exact --nocapture
+          cargo test --locked --lib rate_limit::tests::sabledb_counter_survives_process_replacement_and_is_shared -- --ignored --exact --nocapture
+      - name: Fleet control-plane qualification
+        if: matrix.suite == 'fleet'
+        env:
+          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
+        run: |
+          cargo test --locked --test integration_tests telemetry_survives_24_hour_outage_restart_and_exact_replay -- --ignored --exact --nocapture
+          cargo test --locked --test integration_tests fleet_hierarchy_rejects_cross_organization_and_project_access -- --ignored --exact --nocapture
+          cargo test --locked --test integration_tests remote_mutation_replay_fencing_survives_restart -- --ignored --exact --nocapture
+          cargo test --locked --lib management_rpc::live_tests::remote_management_rpc_is_dual_bound_and_restart_safe -- --ignored --exact --nocapture
+      - name: Fleet analytics qualification
+        if: matrix.suite == 'analytics'
+        env:
+          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
+          RUSTYAUTH_TEST_GREPTIME_URL: http://127.0.0.1:14000
+          RUSTYAUTH_RUN_MEDIUM_ANALYTICS_QUALIFICATION: "1"
+        run: |
+          cargo test --locked --lib telemetry::live_tests::grpc_connector_authenticates_persists_and_exactly_acknowledges -- --ignored --exact --nocapture
+          cargo test --locked --lib analytics_store::tests::live_greptime_reduces_wide_metrics_and_replaces_corrections -- --ignored --exact --nocapture
+          cargo test --locked --lib analytics_archive::tests::signed_archive_import_is_idempotent_and_product_queryable -- --ignored --exact --nocapture
+          cargo test --locked --lib analytics_store::tests::medium_tier_organization_query_meets_the_two_second_p95_target -- --ignored --exact --nocapture
+      - name: Show service logs after failure
+        if: failure()
+        run: docker compose -f compose.integration.yaml logs
+      - name: Stop integration services
+        if: always()
+        run: docker compose -f compose.integration.yaml down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,52 @@ on:
 permissions:
   contents: read
 
+# A superseded PR run has no release value. Cancelling it also prevents several
+# Rust and container builds competing for the same caches and runner capacity.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    name: Changed areas
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      workflow: ${{ steps.select.outputs.workflow }}
+      protocol: ${{ steps.select.outputs.protocol }}
+      client: ${{ steps.select.outputs.client }}
+      site: ${{ steps.select.outputs.site }}
+      policy: ${{ steps.select.outputs.policy }}
+      infrastructure: ${{ steps.select.outputs.infrastructure }}
+      rust: ${{ steps.select.outputs.rust }}
+      console: ${{ steps.select.outputs.console }}
+      api_image: ${{ steps.select.outputs.api_image }}
+      dashboard_image: ${{ steps.select.outputs.dashboard_image }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
+        with:
+          deno-version: 2.9.3
+      - name: Test the change classifier
+        run: deno task ci:test
+      - name: Select required checks
+        id: select
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          deno run --allow-env=BASE_SHA,HEAD_SHA --allow-run=git
+          scripts/ci-changes.ts >> "${GITHUB_OUTPUT}"
+
   workflow-lint:
     name: GitHub Actions syntax and semantics
+    needs: changes
+    if: needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -22,7 +64,10 @@ jobs:
 
   protocol:
     name: Protocol compatibility
+    needs: changes
+    if: needs.changes.outputs.protocol == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,9 +82,12 @@ jobs:
           push: false
           pr_comment: false
 
-  site:
-    name: Site checks
+  client:
+    name: TypeScript client
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
@@ -48,18 +96,46 @@ jobs:
       - run: deno install --frozen
       - run: deno task connect:check
       - run: deno task connect:test
+
+  site:
+    name: Web site
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
+        with:
+          deno-version: 2.9.3
+      - run: deno install --frozen
       - run: deno task docs:check
       - run: deno task gateway:check
+      - run: deno task site:check
+      - run: deno task site:test
+
+  release-policy:
+    name: Release and deployment policy
+    needs: changes
+    if: needs.changes.outputs.policy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
+        with:
+          deno-version: 2.9.3
       - run: deno task native:check
       - run: deno task railway:check
       - run: deno task railway:test
       - run: deno task release:test
-      - run: deno task site:check
-      - run: deno task site:test
 
   infrastructure:
-    name: Infrastructure checks
+    name: Infrastructure correctness
+    needs: changes
+    if: needs.changes.outputs.infrastructure == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     defaults:
       run:
         working-directory: infra/cloudflare
@@ -72,22 +148,13 @@ jobs:
       - run: test -z "$(gofmt -l .)"
       - run: go vet ./...
       - run: go test ./...
-      # The Rust service is gated by cargo-deny, but this module was audited by
-      # nothing — GitHub reported 31 advisories here while `cargo audit` was clean,
-      # because the two cover different ecosystems. govulncheck is used rather than
-      # a version matcher because it reports only vulnerabilities this code can
-      # actually reach.
-      - name: Go vulnerabilities
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
-          "$(go env GOPATH)/bin/govulncheck" ./...
 
-  # Lint and test are independent lanes: neither waits on the other, and each keeps
-  # its own incremental cache. The release build is covered by the container job,
-  # which compiles the same --locked --release profile inside the image.
   rust-lint:
     name: Rust format and lints
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
@@ -98,7 +165,10 @@ jobs:
 
   rust-test:
     name: Rust tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
@@ -106,9 +176,12 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --locked
 
-  console:
-    name: Dioxus console checks
+  console-web:
+    name: Dashboard web correctness
+    needs: changes
+    if: needs.changes.outputs.console == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
@@ -118,212 +191,58 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: console -> target
-      - name: Install Linux native console dependencies
-        run: >-
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends
-          libwebkit2gtk-4.1-dev libxdo-dev libssl-dev
-          libayatana-appindicator3-dev librsvg2-dev
+          key: console-web
       - run: cargo fmt --manifest-path console/Cargo.toml --check
       - run: >-
           cargo clippy --manifest-path console/Cargo.toml --locked
           --target wasm32-unknown-unknown --no-default-features --features web -- -D warnings
-      - run: >-
-          cargo check --manifest-path console/Cargo.toml --locked
-          --no-default-features --features desktop
-      - run: >-
-          cargo test --manifest-path console/Cargo.toml --locked
-          --no-default-features --features desktop
-      - run: >-
-          cargo check --manifest-path console/Cargo.toml --locked
-          --no-default-features --features mobile
 
-  supply-chain:
-    name: Dependency policy
+  console-test:
+    name: Dashboard tests
+    needs: changes
+    if: needs.changes.outputs.console == 'true'
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Every advisory ignore must carry an unexpired `# expires:` comment. Counting
-      # entries against comments is what makes this enforceable: checking only the
-      # entries that volunteer a date lets a new ignore be permanent and silent.
-      - name: Every advisory ignore is dated and unexpired
-        run: |
-          test -f deny.toml || { echo "::error::deny.toml is missing"; exit 1; }
-          ignores="$(grep -c '{ *id *= *"RUSTSEC' deny.toml || true)"
-          dated="$(grep -c '# expires: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' deny.toml || true)"
-          if [[ "${ignores}" -ne "${dated}" ]]; then
-            echo "::error file=deny.toml::${ignores} advisory ignores but ${dated} '# expires:' comments; every ignore needs one"
-            exit 1
-          fi
-          today="$(date -u +%F)"
-          status=0
-          while IFS= read -r expiry; do
-            if [[ "${expiry}" < "${today}" ]]; then
-              echo "::error file=deny.toml::an advisory ignore expired on ${expiry}; re-run the reachability analysis before extending the date"
-              status=1
-            fi
-          done < <(sed -n 's/.*# expires: \([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\).*/\1/p' deny.toml)
-          exit "${status}"
-      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
-        with:
-          rust-version: 1.94.1
-          command: check advisories bans licenses sources
-          # --locked, or the job audits a graph it resolved itself rather than the
-          # Cargo.lock that actually ships.
-          arguments: --all-features --locked
-      - name: Audit independently locked Rust dependency graphs
-        run: |
-          cargo install cargo-audit --version 0.22.2 --locked
-          cargo audit --file console/Cargo.lock
-          cargo audit --file sabledb/Cargo.lock
-
-  recovery-integration:
-    name: Backup and recovery integration
-    runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      # SableDB compiles a whole database from source; build it through the layer
-      # cache once per pinned revision instead of from scratch every run, and load
-      # the tag compose.integration.yaml expects so compose skips its own build.
-      - name: Build the SableDB image through the layer cache
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
-          file: ./sabledb/Dockerfile
-          load: true
-          tags: rustyauth-sabledb:ci
-          cache-from: type=gha,scope=sabledb-image
-          cache-to: type=gha,scope=sabledb-image,mode=max
-      - name: Install checksum-pinned image scanner
-        run: ./scripts/install-trivy.sh "${RUNNER_TEMP}/trivy"
-      - name: Reject HIGH or CRITICAL SableDB image findings
+          workspaces: console -> target
+          key: console-test
+      - name: Install Linux console test dependencies
         run: >-
-          "${RUNNER_TEMP}/trivy/trivy" image --quiet --scanners vuln
-          --severity HIGH,CRITICAL --exit-code 1 rustyauth-sabledb:ci
-      - name: Start real SableDB and S3-compatible services
-        run: >-
-          docker compose -f compose.integration.yaml up -d --wait
-          source-sabledb destination-sabledb minio greptimedb
-      - name: Create the private integration bucket
-        run: docker compose -f compose.integration.yaml run --rm minio-init
-      - name: Run clean-room recovery drill
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-          RUSTYAUTH_TEST_DESTINATION_SABLEDB_URL: redis://127.0.0.1:16380
-          RUSTYAUTH_TEST_S3_ENDPOINT: http://127.0.0.1:19000
-          RUSTYAUTH_TEST_S3_BUCKET: rustyauth-integration
-          RUSTYAUTH_TEST_S3_ACCESS_KEY: rustyauth-test
-          RUSTYAUTH_TEST_S3_SECRET_KEY: rustyauth-test-secret
-        run: >-
-          cargo test --locked --test integration_tests clean_room_backup_restore_and_rotation
-          -- --ignored --exact --nocapture
-      - name: Run Fleet telemetry outage and replay qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --test integration_tests
-          telemetry_survives_24_hour_outage_restart_and_exact_replay
-          -- --ignored --exact --nocapture
-      - name: Run authenticated gRPC telemetry connector qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-          RUSTYAUTH_TEST_GREPTIME_URL: http://127.0.0.1:14000
-        run: >-
-          cargo test --locked --lib
-          telemetry::live_tests::grpc_connector_authenticates_persists_and_exactly_acknowledges
-          -- --ignored --exact --nocapture
-      - name: Run canonical, materialized correction and isolation-purge qualification
-        env:
-          RUSTYAUTH_TEST_GREPTIME_URL: http://127.0.0.1:14000
-        run: >-
-          cargo test --locked --lib
-          analytics_store::tests::live_greptime_reduces_wide_metrics_and_replaces_corrections
-          -- --ignored --exact --nocapture
-      - name: Run signed Parquet recovery convergence qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-          RUSTYAUTH_TEST_GREPTIME_URL: http://127.0.0.1:14000
-        run: >-
-          cargo test --locked --lib
-          analytics_archive::tests::signed_archive_import_is_idempotent_and_product_queryable
-          -- --ignored --exact --nocapture
-      - name: Run medium Fleet Analytics performance gate
-        env:
-          RUSTYAUTH_TEST_GREPTIME_URL: http://127.0.0.1:14000
-          RUSTYAUTH_RUN_MEDIUM_ANALYTICS_QUALIFICATION: "1"
-        run: >-
-          cargo test --locked --lib
-          analytics_store::tests::medium_tier_organization_query_meets_the_two_second_p95_target
-          -- --ignored --exact --nocapture
-      - name: Run Fleet hierarchy isolation qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --test integration_tests
-          fleet_hierarchy_rejects_cross_organization_and_project_access
-          -- --ignored --exact --nocapture
-      - name: Run pinned-SableDB writer-lease renewal qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --lib
-          store::live_store_tests::writer_lease_renews_on_pinned_sabledb_and_fences_a_replaced_owner
-          -- --ignored --exact --nocapture
-      - name: Run shared SableDB rate-limit qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --lib
-          rate_limit::tests::sabledb_counter_survives_process_replacement_and_is_shared
-          -- --ignored --exact --nocapture
-      - name: Run remote-mutation replay qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --test integration_tests
-          remote_mutation_replay_fencing_survives_restart
-          -- --ignored --exact --nocapture
-      - name: Run remote management boundary qualification
-        env:
-          RUSTYAUTH_TEST_SOURCE_SABLEDB_URL: redis://127.0.0.1:16379
-        run: >-
-          cargo test --locked --lib
-          management_rpc::live_tests::remote_management_rpc_is_dual_bound_and_restart_safe
-          -- --ignored --exact --nocapture
-      - name: Show service logs after failure
-        if: failure()
-        run: docker compose -f compose.integration.yaml logs
-      - name: Stop integration services
-        if: always()
-        run: docker compose -f compose.integration.yaml down --volumes
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends
+          libwebkit2gtk-4.1-dev libxdo-dev libssl-dev
+          libayatana-appindicator3-dev librsvg2-dev
+      - run: >-
+          cargo test --manifest-path console/Cargo.toml --locked
+          --no-default-features --features desktop
 
-  container:
+  api-container:
     name: Rust API container build
+    needs: changes
+    if: needs.changes.outputs.api_image == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          load: true
           push: false
           tags: rustyauth:ci
           cache-from: type=gha,scope=rustyauth-image
           cache-to: type=gha,scope=rustyauth-image,mode=max
-      - name: Install checksum-pinned image scanner
-        run: ./scripts/install-trivy.sh "${RUNNER_TEMP}/trivy"
-      - name: Reject HIGH or CRITICAL API image findings
-        run: >-
-          "${RUNNER_TEMP}/trivy/trivy" image --quiet --scanners vuln
-          --severity HIGH,CRITICAL --exit-code 1 rustyauth:ci
 
   dashboard-container:
-    name: Dioxus dashboard container build
+    name: Dashboard container build
+    needs: changes
+    if: needs.changes.outputs.dashboard_image == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -331,17 +250,22 @@ jobs:
         with:
           context: .
           file: Dockerfile.dashboard
-          load: true
           push: false
           tags: rustyauth-dashboard:ci
           cache-from: type=gha,scope=dashboard-image
           cache-to: type=gha,scope=dashboard-image,mode=max
-      - name: Install checksum-pinned image scanner
-        run: ./scripts/install-trivy.sh "${RUNNER_TEMP}/trivy"
-      - name: Reject HIGH or CRITICAL dashboard image findings
-        run: >-
-          "${RUNNER_TEMP}/trivy/trivy" image --quiet --scanners vuln
-          --severity HIGH,CRITICAL --exit-code 1 rustyauth-dashboard:ci
+
+  deployment-templates:
+    name: Deployment template validation
+    needs: changes
+    if: >-
+      needs.changes.outputs.policy == 'true' ||
+      needs.changes.outputs.api_image == 'true' ||
+      needs.changes.outputs.dashboard_image == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate three-service Compose templates
         env:
           AUTH_MASTER_KEY_HEX: compose-validation-only
@@ -353,3 +277,34 @@ jobs:
         run: |
           docker compose -f compose.yaml config --quiet
           docker compose -f compose.fleet.yaml config --quiet
+
+  result:
+    name: CI result
+    if: always()
+    needs:
+      - changes
+      - workflow-lint
+      - protocol
+      - client
+      - site
+      - release-policy
+      - infrastructure
+      - rust-lint
+      - rust-test
+      - console-web
+      - console-test
+      - api-container
+      - dashboard-container
+      - deployment-templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every selected correctness check
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures="$(jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key)=\(.value.result)"' <<<"${NEEDS_JSON}")"
+          if [[ -n "${failures}" ]]; then
+            echo "${failures}"
+            exit 1
+          fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,7 +1,8 @@
 name: Protocol fuzzing
 
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - ".github/workflows/fuzz.yml"
       - "fuzz/**"
@@ -14,6 +15,10 @@ on:
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/native-packaging.yml
+++ b/.github/workflows/native-packaging.yml
@@ -1,11 +1,18 @@
 name: Native preview qualification
 
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - "console/**"
       - ".github/workflows/native-packaging.yml"
+  schedule:
+    - cron: "41 3 * * 1"
   workflow_dispatch:
+
+concurrency:
+  group: native-preview-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/deno.json
+++ b/deno.json
@@ -15,6 +15,7 @@
     "native:check": "deno run --allow-read scripts/check-native-packaging.ts",
     "railway:check": "deno check scripts/railway-rollout.ts",
     "railway:test": "deno test --allow-read --allow-write scripts/railway-rollout.test.ts scripts/railway-workflow.test.ts",
+    "ci:test": "deno test --allow-read scripts/ci-changes.test.ts scripts/ci-workflow.test.ts",
     "release:check": "deno run --allow-read scripts/check-release-readiness.ts",
     "release:test": "deno test --allow-read scripts/check-release-readiness.test.ts",
     "console:dev": "cd console && dx serve --web",

--- a/scripts/check-native-packaging.ts
+++ b/scripts/check-native-packaging.ts
@@ -23,6 +23,9 @@ const requiredWorkflow = [
   "preview-unsigned",
   "if-no-files-found: error",
   "retention-days: 7",
+  "push:",
+  "branches: [main]",
+  "schedule:",
 ];
 const missingWorkflow = requiredWorkflow.filter((value) => !workflow.includes(value));
 
@@ -46,11 +49,11 @@ if (config.includes("signing_identity") || config.includes("certificate_thumbpri
   Deno.exit(1);
 }
 
-if (workflow.includes("push:") || workflow.includes('tags: ["v*"]')) {
+if (workflow.includes('tags: ["v*"]')) {
   console.error("Unsigned native preview packages must not run on or block GA release tags");
   Deno.exit(1);
 }
 
 console.log(
-  "Native preview policy covers ephemeral unsigned macOS, Windows, and Linux packages without coupling them to GA tags.",
+  "Native preview policy covers asynchronous main/scheduled unsigned macOS, Windows, and Linux packages without coupling them to GA tags.",
 );

--- a/scripts/ci-changes.test.ts
+++ b/scripts/ci-changes.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "jsr:@std/assert@1.0.19";
+import { CI_AREAS, classifyCiChanges } from "./ci-changes.ts";
+
+Deno.test("workflow classifier changes force a full qualification", () => {
+  const selected = classifyCiChanges([".github/workflows/ci.yml"]);
+  for (const area of CI_AREAS) assertEquals(selected[area], true, area);
+});
+
+Deno.test("Railway workflow changes stay within workflow and policy lanes", () => {
+  assertEquals(classifyCiChanges([".github/workflows/railway-production.yml"]), {
+    workflow: true,
+    protocol: false,
+    client: false,
+    site: false,
+    policy: true,
+    infrastructure: false,
+    rust: false,
+    console: false,
+    supply_chain: false,
+    recovery: false,
+    api_image: false,
+    dashboard_image: false,
+  });
+});
+
+Deno.test("Rust service changes select runtime, integration and API image lanes", () => {
+  const selected = classifyCiChanges(["src/backup/snapshot.rs"]);
+  assertEquals(selected.rust, true);
+  assertEquals(selected.recovery, true);
+  assertEquals(selected.api_image, true);
+  assertEquals(selected.console, false);
+  assertEquals(selected.dashboard_image, false);
+  assertEquals(selected.site, false);
+});
+
+Deno.test("site-only changes do not compile Rust or containers", () => {
+  const selected = classifyCiChanges(["site/src/pages/index.astro"]);
+  assertEquals(selected.site, true);
+  assertEquals(selected.rust, false);
+  assertEquals(selected.recovery, false);
+  assertEquals(selected.api_image, false);
+  assertEquals(selected.dashboard_image, false);
+});
+
+Deno.test("console changes qualify the dashboard without the API", () => {
+  const selected = classifyCiChanges(["console/src/app.rs"]);
+  assertEquals(selected.console, true);
+  assertEquals(selected.dashboard_image, true);
+  assertEquals(selected.api_image, false);
+  assertEquals(selected.rust, false);
+});
+
+Deno.test("dependency and protocol changes fan out to every consumer", () => {
+  const selected = classifyCiChanges(["Cargo.lock", "proto/rustyauth/fleet/v1/fleet.proto"]);
+  assertEquals(selected.protocol, true);
+  assertEquals(selected.rust, true);
+  assertEquals(selected.console, true);
+  assertEquals(selected.supply_chain, true);
+  assertEquals(selected.recovery, true);
+  assertEquals(selected.api_image, true);
+  assertEquals(selected.dashboard_image, false);
+});
+
+Deno.test("unknown paths fail safe by selecting every lane", () => {
+  const selected = classifyCiChanges(["helm/rustyauth/Chart.yaml"]);
+  for (const area of CI_AREAS) assertEquals(selected[area], true, area);
+});

--- a/scripts/ci-changes.ts
+++ b/scripts/ci-changes.ts
@@ -1,0 +1,145 @@
+export const CI_AREAS = [
+  "workflow",
+  "protocol",
+  "client",
+  "site",
+  "policy",
+  "infrastructure",
+  "rust",
+  "console",
+  "supply_chain",
+  "recovery",
+  "api_image",
+  "dashboard_image",
+] as const;
+
+export type CiArea = (typeof CI_AREAS)[number];
+export type CiSelection = Record<CiArea, boolean>;
+
+const matches = (path: string, patterns: RegExp[]): boolean => patterns.some((pattern) => pattern.test(path));
+
+const sharedMetadata = [
+  /^LICENSE$/,
+  /^NOTICE$/,
+  /^THIRD_PARTY_/,
+  /^about\.(?:hbs|toml)$/,
+];
+
+const patterns: Record<CiArea, RegExp[]> = {
+  workflow: [/^\.github\//, /^scripts\/ci-changes(?:\.test)?\.ts$/],
+  protocol: [/^proto\//, /^buf(?:\.gen)?\.yaml$/, /^packages\/protocol\//, /^build\.rs$/],
+  client: [
+    /^packages\/(?:client|protocol)\//,
+    /^deno\.(?:json|lock)$/,
+  ],
+  site: [
+    /^site\//,
+    /^docs\//,
+    /^assets\//,
+    /^examples\//,
+    /^(?:README|SECURITY|CONTRIBUTING|CODE_OF_CONDUCT|TRADEMARKS)\.md$/,
+    /^packages\/(?:client|protocol)\//,
+    /^deno\.(?:json|lock)$/,
+  ],
+  policy: [
+    /^\.github\/workflows\/(?:release|railway-production|native-packaging)\.yml$/,
+    /^scripts\/(?:railway-|check-release|check-native|check-dashboard|check-docs)/,
+    /^release-evidence\//,
+    /^railway(?:\.[^.]+)?\.json$/,
+    /^sabledb\/railway\.json$/,
+    /^compose(?:\.fleet)?\.yaml$/,
+    /^(?:RELEASING|CHANGELOG)\.md$/,
+    /^docs\/(?:DEPLOYMENT|RAILWAY_TEMPLATE|RELEASE_READINESS|NATIVE_PACKAGING)\.md$/,
+    /^deno\.(?:json|lock)$/,
+  ],
+  infrastructure: [/^infra\/cloudflare\//],
+  rust: [
+    /^src\//,
+    /^tests\//,
+    /^Cargo\.(?:toml|lock)$/,
+    /^rust-toolchain\.toml$/,
+    /^build\.rs$/,
+    /^proto\//,
+    /^schemas\//,
+    /^rustyauth(?:\.fleet)?\.example\.yaml$/,
+  ],
+  console: [
+    /^console\//,
+    /^Dockerfile\.dashboard$/,
+    /^proto\//,
+  ],
+  supply_chain: [
+    /^(?:Cargo|deno)\.(?:toml|json|lock)$/,
+    /^console\/Cargo\.(?:toml|lock)$/,
+    /^sabledb\/Cargo\.lock$/,
+    /^fuzz\/Cargo\.(?:toml|lock)$/,
+    /^deny\.toml$/,
+    /^Dockerfile(?:\.dashboard)?$/,
+    /^sabledb\/Dockerfile$/,
+    ...sharedMetadata,
+  ],
+  recovery: [
+    /^src\//,
+    /^tests\//,
+    /^Cargo\.(?:toml|lock)$/,
+    /^rust-toolchain\.toml$/,
+    /^build\.rs$/,
+    /^proto\//,
+    /^compose\.integration\.yaml$/,
+    /^sabledb\//,
+  ],
+  api_image: [
+    /^Dockerfile$/,
+    /^src\//,
+    /^Cargo\.(?:toml|lock)$/,
+    /^rust-toolchain\.toml$/,
+    /^build\.rs$/,
+    /^proto\//,
+    /^rustyauth(?:\.fleet)?\.example\.yaml$/,
+    ...sharedMetadata,
+  ],
+  dashboard_image: [
+    /^Dockerfile\.dashboard$/,
+    /^console\//,
+    ...sharedMetadata,
+  ],
+};
+
+const fullQualificationPaths = [
+  /^\.github\/workflows\/ci\.yml$/,
+  /^scripts\/ci-changes(?:\.test)?\.ts$/,
+];
+
+export function classifyCiChanges(paths: string[]): CiSelection {
+  const normalized = paths.map((path) => path.trim()).filter(Boolean);
+  // A newly introduced top-level area must not silently bypass CI just because
+  // this classifier has not learned it yet. Unknown paths conservatively run all
+  // lanes until an explicit mapping is added.
+  const unknown = normalized.some(
+    (path) => !CI_AREAS.some((area) => matches(path, patterns[area])),
+  );
+  const all = unknown || normalized.some((path) => matches(path, fullQualificationPaths));
+  return Object.fromEntries(
+    CI_AREAS.map((area) => [
+      area,
+      all || normalized.some((path) => matches(path, patterns[area])),
+    ]),
+  ) as CiSelection;
+}
+
+async function changedPaths(base: string, head: string): Promise<string[]> {
+  const validBase = base && !/^0+$/.test(base);
+  // Deletions matter: removing a source, manifest or workflow file must qualify
+  // the same consumers as changing it.
+  const args = validBase ? ["diff", "--name-only", "--diff-filter=ACMRD", base, head] : ["ls-files"];
+  const result = await new Deno.Command("git", { args, stdout: "piped", stderr: "inherit" }).output();
+  if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+  return new TextDecoder().decode(result.stdout).split("\n");
+}
+
+if (import.meta.main) {
+  const base = Deno.env.get("BASE_SHA") ?? "";
+  const head = Deno.env.get("HEAD_SHA") ?? "HEAD";
+  const selected = classifyCiChanges(await changedPaths(base, head));
+  for (const area of CI_AREAS) console.log(`${area}=${selected[area]}`);
+}

--- a/scripts/ci-workflow.test.ts
+++ b/scripts/ci-workflow.test.ts
@@ -1,0 +1,44 @@
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert@1.0.19";
+
+const read = (path: string): string => Deno.readTextFileSync(new URL(`../${path}`, import.meta.url));
+
+const ci = read(".github/workflows/ci.yml");
+const assurance = read(".github/workflows/assurance.yml");
+const fuzz = read(".github/workflows/fuzz.yml");
+const native = read(".github/workflows/native-packaging.yml");
+
+Deno.test("blocking CI is change-aware and exposes one stable result", () => {
+  assertStringIncludes(ci, "name: Changed areas");
+  assertStringIncludes(ci, "name: CI result");
+  assertStringIncludes(ci, "cancel-in-progress: true");
+  assertStringIncludes(ci, "needs.changes.outputs.rust == 'true'");
+  assertStringIncludes(ci, "needs.changes.outputs.console == 'true'");
+  assertStringIncludes(ci, "scope=rustyauth-image");
+  assertStringIncludes(ci, "scope=dashboard-image");
+});
+
+Deno.test("deep security and qualification are outside the merge gate", () => {
+  for (
+    const command of [
+      "govulncheck",
+      "cargo audit",
+      "trivy",
+      "CodeQL",
+      "medium_tier_organization_query_meets_the_two_second_p95_target",
+    ]
+  ) {
+    assertEquals(ci.includes(command), false, command);
+    assert(assurance.includes(command), command);
+  }
+  assertStringIncludes(assurance, "schedule:");
+  assertStringIncludes(assurance, "branches: [main]");
+});
+
+Deno.test("fuzzing and native preview qualification run after merge or on schedules", () => {
+  for (const workflow of [fuzz, native]) {
+    assertEquals(workflow.includes("pull_request:"), false);
+    assertStringIncludes(workflow, "push:");
+    assertStringIncludes(workflow, "branches: [main]");
+    assertStringIncludes(workflow, "schedule:");
+  }
+});


### PR DESCRIPTION
## Outcome

- gate merges on changed-code correctness through one stable `CI result` check
- split client, site, policy, Rust, dashboard, infrastructure and image builds into concurrent lanes
- move CodeQL, dependency audits, container scanning and full runtime qualification to asynchronous main/nightly assurance
- move fuzzing and native preview packaging off pull requests
- reuse Rust and BuildKit caches and cancel superseded runs
- fail safe to full CI for unknown paths

## Validation

- `deno task ci:test` (10 tests)
- Deno formatting and type checks
- Actionlint 1.7.12 over all workflows
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces unconditional pull-request qualification with path-selected correctness lanes aggregated behind one stable `CI result`, while moving expensive security, runtime, fuzzing, and native packaging checks to post-merge assurance.

- Adds a conservative changed-path classifier with tests and full-CI fallback for unknown paths.
- Splits client, site, policy, Rust, dashboard, infrastructure, and container checks into concurrent conditional jobs.
- Adds scheduled/main assurance for CodeQL, dependency audits, image scanning, and live runtime qualification.
- Moves fuzzing and native preview packaging from pull requests to main and scheduled execution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete unacknowledged correctness defect identified in the changed release-check architecture.

The classifier fails safe for unknown paths, selected jobs are aggregated so failures and cancellations reject the stable result, and the removed pull-request security and runtime checks are intentionally retained in main and scheduled assurance.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci-changes.ts | Introduces path-based lane selection, conservative unknown-path fallback, and Git-based changed-file discovery. |
| .github/workflows/ci.yml | Reorganizes pull-request correctness checks into conditional concurrent lanes and aggregates their outcomes in a stable result job. |
| .github/workflows/assurance.yml | Adds post-merge and scheduled security scanning, dependency auditing, image scanning, and live runtime qualification. |
| scripts/ci-changes.test.ts | Covers full qualification, representative area mappings, consumer fan-out, and unknown-path fail-safe behavior. |
| scripts/ci-workflow.test.ts | Verifies the intended workflow split and stable result structure through focused textual assertions. |
| scripts/check-native-packaging.ts | Updates native preview policy validation to require asynchronous main and scheduled execution while continuing to reject release-tag coupling. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Pull request or main push] --> B[Changed areas classifier]
  B --> C{Selected correctness lanes}
  C --> D[Workflow and protocol]
  C --> E[Client site and policy]
  C --> F[Rust and dashboard]
  C --> G[Infrastructure and images]
  D --> H[CI result]
  E --> H
  F --> H
  G --> H
  I[Main push or schedule] --> J[Continuous assurance]
  J --> K[CodeQL and dependency audits]
  J --> L[Container scanning]
  J --> M[Runtime qualification]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: validate asynchronous native preview..."](https://github.com/rusty-auth/rustyauth/commit/ca9429d488b2227469b9357a327e67e68ba11038) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51612035)</sub>

<!-- /greptile_comment -->