### PR TITLE
ci: keep assurance behind the release gate

### DIFF
--- a/.github/workflows/assurance.yml
+++ b/.github/workflows/assurance.yml
@@ -1,7 +1,9 @@
 name: Continuous assurance
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
   schedule:
     - cron: "23 2 * * *"
@@ -38,6 +40,8 @@ jobs:
             build_mode: autobuild
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Initialize CodeQL
         uses: github/codeql-action/init@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
         with:
@@ -55,6 +59,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Every advisory ignore is dated and unexpired
         run: |
           test -f deny.toml || { echo "::error::deny.toml is missing"; exit 1; }
@@ -93,6 +99,8 @@ jobs:
         working-directory: infra/cloudflare
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: infra/cloudflare/go.mod
@@ -124,6 +132,8 @@ jobs:
             cache_scope: sabledb-image
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build ${{ matrix.name }} through the shared layer cache
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -151,6 +161,8 @@ jobs:
         suite: [backup, fleet, analytics]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.94.1 --profile minimal
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           --target wasm32-unknown-unknown --no-default-features --features web -- -D warnings
 
   console-test:
-    name: Dashboard tests
+    name: Dashboard core tests
     needs: changes
     if: needs.changes.outputs.console == 'true'
     runs-on: ubuntu-latest
@@ -211,14 +211,9 @@ jobs:
         with:
           workspaces: console -> target
           key: console-test
-      - name: Install Linux console test dependencies
-        run: >-
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends
-          libwebkit2gtk-4.1-dev libxdo-dev libssl-dev
-          libayatana-appindicator3-dev librsvg2-dev
       - run: >-
           cargo test --manifest-path console/Cargo.toml --locked
-          --no-default-features --features desktop
+          --no-default-features
 
   api-container:
     name: Rust API container build

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,17 +1,6 @@
 name: Protocol fuzzing
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/fuzz.yml"
-      - "fuzz/**"
-      - "proto/**"
-      - "src/analytics.rs"
-      - "src/telemetry.rs"
-      - "build.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:

--- a/.github/workflows/native-packaging.yml
+++ b/.github/workflows/native-packaging.yml
@@ -1,11 +1,6 @@
 name: Native preview qualification
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "console/**"
-      - ".github/workflows/native-packaging.yml"
   schedule:
     - cron: "41 3 * * 1"
   workflow_dispatch:

--- a/scripts/check-native-packaging.ts
+++ b/scripts/check-native-packaging.ts
@@ -23,9 +23,8 @@ const requiredWorkflow = [
   "preview-unsigned",
   "if-no-files-found: error",
   "retention-days: 7",
-  "push:",
-  "branches: [main]",
   "schedule:",
+  "workflow_dispatch:",
 ];
 const missingWorkflow = requiredWorkflow.filter((value) => !workflow.includes(value));
 
@@ -49,11 +48,11 @@ if (config.includes("signing_identity") || config.includes("certificate_thumbpri
   Deno.exit(1);
 }
 
-if (workflow.includes('tags: ["v*"]')) {
-  console.error("Unsigned native preview packages must not run on or block GA release tags");
+if (workflow.includes("push:") || workflow.includes("pull_request:") || workflow.includes('tags: ["v*"]')) {
+  console.error("Unsigned native preview packages must remain scheduled/manual and must not block GA work");
   Deno.exit(1);
 }
 
 console.log(
-  "Native preview policy covers asynchronous main/scheduled unsigned macOS, Windows, and Linux packages without coupling them to GA tags.",
+  "Native preview policy covers scheduled/manual unsigned macOS, Windows, and Linux packages without coupling them to GA work.",
 );

--- a/scripts/ci-workflow.test.ts
+++ b/scripts/ci-workflow.test.ts
@@ -31,14 +31,16 @@ Deno.test("deep security and qualification are outside the merge gate", () => {
     assert(assurance.includes(command), command);
   }
   assertStringIncludes(assurance, "schedule:");
+  assertStringIncludes(assurance, "workflow_run:");
   assertStringIncludes(assurance, "branches: [main]");
+  assertStringIncludes(assurance, "github.event.workflow_run.head_sha || github.sha");
 });
 
-Deno.test("fuzzing and native preview qualification run after merge or on schedules", () => {
+Deno.test("fuzzing and native preview qualification remain scheduled or manual", () => {
   for (const workflow of [fuzz, native]) {
     assertEquals(workflow.includes("pull_request:"), false);
-    assertStringIncludes(workflow, "push:");
-    assertStringIncludes(workflow, "branches: [main]");
+    assertEquals(workflow.includes("push:"), false);
     assertStringIncludes(workflow, "schedule:");
+    assertStringIncludes(workflow, "workflow_dispatch:");
   }
 });


### PR DESCRIPTION
## Outcome

- start continuous assurance only after main CI has completed, while retaining nightly/manual runs
- check out the exact triggering main commit during workflow-run assurance
- keep fuzzing and unsigned native preview packaging scheduled/manual only
- test the dashboard platform-neutral core in blocking CI without GTK or desktop renderer compilation

## Validation

- `deno task ci:test` (10 tests)
- `deno task native:check`
- Actionlint 1.7.12 over all workflows
- `cargo test --manifest-path console/Cargo.toml --locked --no-default-features` (3 tests)
- Deno type/format checks and `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves continuous assurance behind completion of the main CI workflow, preserves scheduled/manual assurance paths, and narrows blocking dashboard tests to the platform-neutral core. It also makes fuzzing and unsigned native packaging scheduled/manual only.

- Assurance checks out the exact triggering CI commit for workflow-run events.
- Dashboard core tests no longer install GTK dependencies or enable the desktop renderer.
- Fuzzing and native preview packaging no longer run on pushes to main.
- Policy tests were updated to enforce the new workflow triggers.

<h3>Confidence Score: 4/5</h3>

The unsuccessful-CI path should be gated before merging so failed or cancelled main builds cannot launch or supersede continuous assurance.

The workflow_run trigger handles every completed CI conclusion, causing expensive assurance jobs to run for known-bad commits and potentially cancel assurance for the prior successful commit.

**Files Needing Attention:** .github/workflows/assurance.yml, scripts/ci-workflow.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/assurance.yml | Replaces the main push trigger with workflow_run and checks out its head SHA, but does not restrict downstream assurance to successful CI conclusions. |
| .github/workflows/ci.yml | Changes dashboard CI to test its platform-neutral core without GTK packages or the desktop feature. |
| .github/workflows/fuzz.yml | Removes push-to-main fuzzing while retaining weekly and manual execution. |
| .github/workflows/native-packaging.yml | Removes push-to-main native preview qualification while retaining weekly and manual execution. |
| scripts/check-native-packaging.ts | Updates native-packaging policy validation to require scheduled/manual-only execution. |
| scripts/ci-workflow.test.ts | Updates workflow assertions for the new triggers but does not assert that assurance requires a successful triggering CI run. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Push to main] --> B[CI workflow]
  B -->|completed: success| C[Continuous assurance]
  B -->|completed: failure or cancellation| C
  D[Nightly schedule] --> C
  E[Manual dispatch] --> C
  C --> F[Checkout triggering head SHA]
  F --> G[CodeQL and dependency checks]
  F --> H[Container security scans]
  F --> I[Runtime qualification]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Fdefer-assurance-after-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdefer-assurance-after-ci%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fassurance.yml%3A6%0A**Unsuccessful%20CI%20still%20starts%20assurance**%0A%0AWhen%20a%20main-branch%20CI%20run%20fails%20or%20is%20cancelled%2C%20the%20%60completed%60%20event%20still%20starts%20every%20assurance%20job%20because%20no%20job%20checks%20%60github.event.workflow_run.conclusion%60%2C%20causing%20a%20known-bad%20commit%20to%20consume%20the%20full%20assurance%20workload%20and%20potentially%20supersede%20assurance%20for%20the%20preceding%20successful%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fassurance.yml%3A6%0A**Unsuccessful%20CI%20still%20starts%20assurance**%0A%0AWhen%20a%20main-branch%20CI%20run%20fails%20or%20is%20cancelled%2C%20the%20%60completed%60%20event%20still%20starts%20every%20assurance%20job%20because%20no%20job%20checks%20%60github.event.workflow_run.conclusion%60%2C%20causing%20a%20known-bad%20commit%20to%20consume%20the%20full%20assurance%20workload%20and%20potentially%20supersede%20assurance%20for%20the%20preceding%20successful%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/assurance.yml:6
**Unsuccessful CI still starts assurance**

When a main-branch CI run fails or is cancelled, the `completed` event still starts every assurance job because no job checks `github.event.workflow_run.conclusion`, causing a known-bad commit to consume the full assurance workload and potentially supersede assurance for the preceding successful commit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: keep assurance behind the release ga..."](https://github.com/rusty-auth/rustyauth/commit/44ad18f0b5502138ad770917ad5824f628e25b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51613393)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->