### PR TITLE
ci: cancel superseded pipelines

### DIFF
--- a/.github/workflows/assurance.yml
+++ b/.github/workflows/assurance.yml
@@ -15,8 +15,11 @@ permissions:
 # Assurance follows main and is intentionally independent of the release gate.
 # Only the newest main revision needs the expensive qualification pass.
 concurrency:
-  group: assurance-${{ github.ref }}
-  cancel-in-progress: true
+  # Main-triggered assurance shares the main CI group: a new merge therefore
+  # preempts old assurance before it can compete with the latest correctness run.
+  # Scheduled/manual assurance queues behind CI and cannot cancel it.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
 
 jobs:
   codeql:

--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: railway-production
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   prepare:
@@ -318,7 +318,7 @@ jobs:
           --health-url "${RAILWAY_DASHBOARD_URL%/}/readyz"
           --receipt "${RUNNER_TEMP}/railway-receipts/sabledb.json"
       - name: Restore the previous Railway deployment set
-        if: failure()
+        if: failure() || cancelled()
         run: |
           rollback_failed=0
           rollback_service() {
@@ -380,7 +380,7 @@ jobs:
           rollback_service "${RUNNER_TEMP}/railway-receipts/api.json"
           exit "${rollback_failed}"
       - name: Show bounded deployment logs on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           for service in \
             "${RAILWAY_API_SERVICE_ID}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,13 @@ on:
 permissions:
   contents: read
 
+# A retrigger for the same immutable tag supersedes its older attempt. Different
+# release tags remain isolated so a newer release cannot interrupt publication of
+# another version.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     name: Verify tag and tests

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -1,4 +1,5 @@
 const workflow = await Deno.readTextFile(".github/workflows/railway-production.yml");
+const releaseWorkflow = await Deno.readTextFile(".github/workflows/release.yml");
 const rollout = await Deno.readTextFile("scripts/railway-rollout.ts");
 
 function assertIncludes(source: string, required: string): void {
@@ -24,7 +25,7 @@ Deno.test("Railway automatic deployments follow successful current-main CI only"
       "git merge-base --is-ancestor",
       "Skipping stale successful CI result",
       "group: railway-production",
-      "cancel-in-progress: false",
+      "cancel-in-progress: true",
       "RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}",
     ]
   ) assertIncludes(workflow, required);
@@ -65,6 +66,7 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
 
 Deno.test("a partial Railway rollout restores services and browser origin in reverse order", () => {
   assertIncludes(workflow, "name: Restore the previous Railway deployment set");
+  assertIncludes(workflow, "if: failure() || cancelled()");
   assertOrdered(workflow, [
     'rollback_service "${RUNNER_TEMP}/railway-receipts/sabledb.json"',
     'rollback_service "${RUNNER_TEMP}/railway-receipts/dashboard.json"',
@@ -73,4 +75,9 @@ Deno.test("a partial Railway rollout restores services and browser origin in rev
   ]);
   assertIncludes(workflow, "railway down");
   assertIncludes(rollout, "healthVerifiedAt: null");
+});
+
+Deno.test("same-revision release retries cancel without crossing tag boundaries", () => {
+  assertIncludes(releaseWorkflow, "group: release-${{ github.ref }}");
+  assertIncludes(releaseWorkflow, "cancel-in-progress: true");
 });


### PR DESCRIPTION
## Outcome

- cancel superseded Railway main build/deploy runs
- run Railway rollback handling when a deployment is cancelled
- cancel retriggers of the same release tag without allowing one version to interrupt another
- preserve existing latest-only CI, assurance, fuzz and native-preview concurrency

## Validation

- `deno task railway:test` (12 tests)
- `deno task ci:test` (10 tests)
- Actionlint 1.7.12 over all workflows
- Deno type/format checks and `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes GitHub Actions concurrency so superseded Railway deployments and same-tag release attempts are cancelled while preserving tag isolation and latest-main qualification behavior.

- Shares main assurance concurrency with CI and conditionally enables preemption.
- Enables Railway deployment cancellation and runs rollback/log collection on cancellation.
- Adds per-tag release concurrency and workflow assertions for the new behavior.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until same-tag cancellation is prevented from interrupting irreversible multi-package publication.

A replacement run can cancel its predecessor between two immutable JSR publishes, after which the replacement is rejected by preflight and cannot finish the release.

**Files Needing Attention:** .github/workflows/release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/assurance.yml | Shares assurance with main CI concurrency while limiting cancellation initiated by assurance to workflow-run events. |
| .github/workflows/railway-production.yml | Cancels superseded deployments and extends rollback and diagnostic steps to cancellation paths. |
| .github/workflows/release.yml | Adds per-tag cancellation, but cancellation can interrupt the irreversible two-package JSR publication and make the replacement run fail preflight. |
| scripts/railway-workflow.test.ts | Adds textual assertions for Railway cancellation rollback and per-tag release concurrency. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R1 as Existing same-tag release
    participant GHA as GitHub Actions concurrency
    participant JSR as JSR registry
    participant R2 as Replacement release
    R1->>JSR: Publish protocol version
    R2->>GHA: Start with same release-tag group
    GHA-->>R1: Cancel in-progress run
    Note over R1,JSR: Client version may remain unpublished
    R2->>JSR: Preflight both package versions
    JSR-->>R2: Protocol version already exists
    R2-->>R2: Release fails before remaining publication
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Fcancel-superseded-pipelines%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fcancel-superseded-pipelines%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frelease.yml%3A15%0A**Cancellation%20breaks%20atomic%20publication**%0A%0AWhen%20a%20replacement%20run%20for%20the%20same%20tag%20starts%20after%20%60%40rustyauth%2Fprotocol%60%20is%20published%20but%20before%20%60%40rustyauth%2Fclient%60%20is%20published%2C%20this%20concurrency%20setting%20cancels%20the%20first%20run%20and%20leaves%20the%20release%20partially%20published.%20The%20replacement%20then%20fails%20preflight%20because%20the%20immutable%20protocol%20version%20already%20exists%2C%20preventing%20publication%20of%20the%20client%20package%20and%20creation%20of%20the%20GitHub%20release%20without%20manual%20recovery.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frelease.yml%3A15%0A**Cancellation%20breaks%20atomic%20publication**%0A%0AWhen%20a%20replacement%20run%20for%20the%20same%20tag%20starts%20after%20%60%40rustyauth%2Fprotocol%60%20is%20published%20but%20before%20%60%40rustyauth%2Fclient%60%20is%20published%2C%20this%20concurrency%20setting%20cancels%20the%20first%20run%20and%20leaves%20the%20release%20partially%20published.%20The%20replacement%20then%20fails%20preflight%20because%20the%20immutable%20protocol%20version%20already%20exists%2C%20preventing%20publication%20of%20the%20client%20package%20and%20creation%20of%20the%20GitHub%20release%20without%20manual%20recovery.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/release.yml:15
**Cancellation breaks atomic publication**

When a replacement run for the same tag starts after `@rustyauth/protocol` is published but before `@rustyauth/client` is published, this concurrency setting cancels the first run and leaves the release partially published. The replacement then fails preflight because the immutable protocol version already exists, preventing publication of the client package and creation of the GitHub release without manual recovery.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: let main preempt asynchronous assura..."](https://github.com/rusty-auth/rustyauth/commit/69ee539fb5209e2ee77f4c7fa5aed1be56f97811) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51615135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->