### PR TITLE
fix: recover failed Railway candidate deployments

### DIFF
--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -1,4 +1,5 @@
 import {
+  configuredServiceImage,
   deploymentMatchesProfile,
   matchingDeployment,
   normalizeDigest,
@@ -37,6 +38,22 @@ function deployment(id: string, status: string, target = true): RailwayDeploymen
   };
 }
 
+function projectStatus(configuredImage = "ghcr.io/rusty-auth/rustyauth@sha256:older"): string {
+  return JSON.stringify({
+    environments: {
+      edges: [{
+        node: {
+          id: "production",
+          name: "production",
+          serviceInstances: {
+            edges: [{ node: { serviceId: "api", serviceName: "api", source: { image: configuredImage } } }],
+          },
+        },
+      }],
+    },
+  });
+}
+
 Deno.test("Railway service profiles preserve the one-writer and readiness policies", () => {
   assertEquals(serviceUpdateInput("realm", image), {
     source: { image },
@@ -70,11 +87,13 @@ Deno.test("deployment parsing and matching require the exact image and digest", 
   assertEquals(pinnedImageReference(image, digest), sourceImage);
   assertEquals(pinnedImageReference(`${image}@${digest}`, digest), sourceImage);
   assert(deploymentMatchesProfile(deployments[1], "realm"), "candidate policy did not match");
+  assertEquals(configuredServiceImage(projectStatus(sourceImage), "production", "api"), sourceImage);
 });
 
 Deno.test("a historical matching image is not mistaken for the active deployment", async () => {
   const outputs = [
     JSON.stringify([deployment("current", "SUCCESS", false), deployment("historical", "SUCCESS")]),
+    projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("current", "SUCCESS", false)]),
   ];
@@ -108,6 +127,7 @@ Deno.test("a historical matching image is not mistaken for the active deployment
 Deno.test("rollout waits for the exact digest to reach terminal success before health checks", async () => {
   const outputs = [
     JSON.stringify([deployment("old", "SUCCESS", false)]),
+    projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
     JSON.stringify([deployment("queued", "QUEUED"), deployment("old", "SUCCESS", false)]),
     JSON.stringify([deployment("new", "DEPLOYING"), deployment("old", "SUCCESS", false)]),
@@ -163,6 +183,7 @@ Deno.test("a deployment receipt exists before a failing health check so rollback
   const receiptPath = await Deno.makeTempFile();
   const outputs = [
     JSON.stringify([deployment("old", "SUCCESS", false)]),
+    projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
   ];
@@ -232,10 +253,49 @@ Deno.test("rollout is idempotent when the exact successful digest is already act
   assertEquals(calls, 1);
 });
 
+Deno.test("rollout forces a fresh deployment when the desired source previously failed", async () => {
+  const outputs = [
+    JSON.stringify([deployment("failed", "FAILED")]),
+    projectStatus(sourceImage),
+    JSON.stringify({ id: "requested" }),
+    JSON.stringify([deployment("new", "SUCCESS"), deployment("failed", "FAILED")]),
+  ];
+  const commands: string[][] = [];
+  const runner: RailwayRunner = (args) => {
+    commands.push(args);
+    return Promise.resolve({ code: 0, stdout: outputs.shift() ?? "[]", stderr: "" });
+  };
+  const receipt = await rolloutRailwayImage(
+    {
+      project: "project",
+      environment: "production",
+      service: "api",
+      profile: "realm",
+      image,
+      digest,
+      healthUrls: [],
+      timeoutMs: 100,
+      pollMs: 1,
+    },
+    runner,
+    () => Promise.resolve(),
+    () => new Date(0),
+    () => Promise.resolve(),
+  );
+
+  assertEquals(receipt.deploymentId, "new");
+  assertEquals(receipt.changed, true);
+  assert(!commands.some((args) => args[0] === "api"), "unchanged source should not be updated again");
+  const redeploy = commands.find((args) => args[0] === "redeploy");
+  assert(redeploy?.includes("--from-source"), "failed configured source was not redeployed");
+  assert(redeploy?.includes("--yes"), "redeploy was not non-interactive");
+});
+
 Deno.test("rollout fails closed on a terminal failed deployment", async () => {
   const receiptPath = await Deno.makeTempFile();
   const outputs = [
     JSON.stringify([deployment("old", "SUCCESS", false)]),
+    projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
     JSON.stringify([deployment("failed", "FAILED")]),
   ];

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -171,6 +171,43 @@ export function parseDeployments(raw: string): RailwayDeployment[] {
   });
 }
 
+export function configuredServiceImage(
+  raw: string,
+  environment: string,
+  service: string,
+): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    fail("Railway status did not return valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object") fail("Railway status was not an object");
+  const environments = (parsed as {
+    environments?: { edges?: Array<{ node?: Record<string, unknown> }> };
+  }).environments?.edges;
+  if (!Array.isArray(environments)) fail("Railway status is missing environments");
+
+  for (const edge of environments) {
+    const environmentNode = edge.node;
+    if (!environmentNode) continue;
+    if (environmentNode.id !== environment && environmentNode.name !== environment) continue;
+    const instances = (environmentNode.serviceInstances as {
+      edges?: Array<{ node?: Record<string, unknown> }>;
+    } | undefined)?.edges;
+    if (!Array.isArray(instances)) fail("Railway status is missing service instances");
+    const instance = instances
+      .map((candidate) => candidate.node)
+      .find((candidate) => candidate?.serviceId === service || candidate?.serviceName === service);
+    if (!instance) fail(`Railway status is missing service ${service}`);
+    const image = (instance.source as { image?: unknown } | undefined)?.image;
+    if (image === null || image === undefined) return null;
+    if (typeof image !== "string") fail(`Railway service ${service} has an invalid source image`);
+    return image;
+  }
+  fail(`Railway status is missing environment ${environment}`);
+}
+
 export function matchingDeployment(
   deployments: RailwayDeployment[],
   image: string,
@@ -223,6 +260,32 @@ function deploymentListArgs(options: RailwayRolloutOptions): string[] {
     options.service,
     "--limit",
     "20",
+    "--json",
+  ];
+}
+
+function projectStatusArgs(options: RailwayRolloutOptions): string[] {
+  return [
+    "status",
+    "--project",
+    options.project,
+    "--environment",
+    options.environment,
+    "--json",
+  ];
+}
+
+function redeployArgs(options: RailwayRolloutOptions): string[] {
+  return [
+    "redeploy",
+    "--project",
+    options.project,
+    "--environment",
+    options.environment,
+    "--service",
+    options.service,
+    "--from-source",
+    "--yes",
     "--json",
   ];
 }
@@ -313,12 +376,21 @@ export async function rolloutRailwayImage(
   if (current?.status === "SUCCESS" && deploymentMatchesProfile(current, options.profile)) {
     deployment = current;
   } else {
-    const update = JSON.parse(await runJson(runner, updateArgs(options, sourceImage))) as {
-      data?: { serviceInstanceUpdate?: boolean };
-      errors?: unknown[];
-    };
-    if (update.errors?.length || update.data?.serviceInstanceUpdate !== true) {
-      fail("Railway rejected the service image/configuration update");
+    const configuredImage = configuredServiceImage(
+      await runJson(runner, projectStatusArgs(options)),
+      options.environment,
+      options.service,
+    );
+    if (configuredImage === sourceImage) {
+      await runJson(runner, redeployArgs(options));
+    } else {
+      const update = JSON.parse(await runJson(runner, updateArgs(options, sourceImage))) as {
+        data?: { serviceInstanceUpdate?: boolean };
+        errors?: unknown[];
+      };
+      if (update.errors?.length || update.data?.serviceInstanceUpdate !== true) {
+        fail("Railway rejected the service image/configuration update");
+      }
     }
     receipt.changed = true;
     await writeReceipt();

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -43,6 +43,9 @@ Deno.test("Railway candidates are immutable, signed and digest-verified", () => 
       "matchingDeployment(deployments, sourceImage, digest, baselineIds)",
       "pinnedImageReference(options.image, digest)",
       'candidate.status === "SUCCESS"',
+      "configuredImage === sourceImage",
+      '"redeploy"',
+      '"--from-source"',
     ]
   ) assertIncludes(workflow + rollout, required);
   if (/tags:.*:latest/.test(workflow)) {


### PR DESCRIPTION
## Summary

- detect when the exact immutable candidate image is already configured in Railway
- force a fresh non-interactive redeploy after a failed candidate deployment instead of waiting on a no-op source update
- preserve the existing digest, deployment-policy, receipt, rollback, and health verification gates
- cover the failed-configured-source recovery path and workflow invariant

## Validation

- `deno task railway:check`
- `deno task railway:test`
- `deno task release:test`
- `deno task ci:test`
- production Railway status JSON parsed successfully for the pinned API candidate

## Production impact

This repairs the automated main-branch production rollout. After merge and green CI, the Railway workflow will redeploy the API candidate, then deploy the dashboard and SableDB serially with health checks and rollback receipts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Railway recovery for a failed deployment whose immutable candidate image is already configured, selecting a non-interactive source redeploy rather than repeating a no-op update.

- Parses the configured service image from Railway project status.
- Adds the forced redeploy path and coverage for a previously failed candidate.
- Extends workflow invariant checks for the recovery command.

<h3>Confidence Score: 4/5</h3>

The retry behavior should be fixed before merging because it can start a duplicate Railway deployment when the desired candidate is already progressing.

The new configured-source branch treats every non-successful matching candidate as failed, then excludes the existing candidate from polling after forcing another deployment.

**Files Needing Attention:** scripts/railway-rollout.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/railway-rollout.ts | Adds status parsing and configured-source redeployment, but also redeploys when a matching candidate is still in progress. |
| scripts/railway-rollout.test.ts | Covers failed-source recovery and updates existing command fixtures, but does not exercise an already nonterminal matching candidate. |
| scripts/railway-workflow.test.ts | Extends static workflow invariants to require configured-image comparison and source redeployment flags. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Rollout workflow
  participant R as Railway
  W->>R: List candidate deployments
  R-->>W: Matching candidate is still DEPLOYING
  W->>R: Read configured service image
  R-->>W: Desired immutable image
  W->>R: redeploy --from-source
  Note over R: A second deployment is started
  W->>R: Poll excluding baseline deployment IDs
  Note over W,R: Original candidate success is ignored
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-railway-redeploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-railway-redeploy%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Frailway-rollout.ts%3A384-385%0A**In-progress%20candidates%20trigger%20duplicate%20redeploys**%0A%0AIf%20a%20matching%20candidate%20remains%20nonterminal%20after%20a%20workflow%20cancellation%2C%20this%20branch%20starts%20another%20redeploy%2C%20then%20excludes%20the%20original%20deployment%20through%20%60baselineIds%60%2C%20causing%20the%20rollout%20to%20fail%20or%20time%20out%20on%20the%20replacement%20even%20when%20the%20original%20successfully%20activates%20the%20desired%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Frailway-rollout.ts%3A384-385%0A**In-progress%20candidates%20trigger%20duplicate%20redeploys**%0A%0AIf%20a%20matching%20candidate%20remains%20nonterminal%20after%20a%20workflow%20cancellation%2C%20this%20branch%20starts%20another%20redeploy%2C%20then%20excludes%20the%20original%20deployment%20through%20%60baselineIds%60%2C%20causing%20the%20rollout%20to%20fail%20or%20time%20out%20on%20the%20replacement%20even%20when%20the%20original%20successfully%20activates%20the%20desired%20image.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/railway-rollout.ts:384-385
**In-progress candidates trigger duplicate redeploys**

If a matching candidate remains nonterminal after a workflow cancellation, this branch starts another redeploy, then excludes the original deployment through `baselineIds`, causing the rollout to fail or time out on the replacement even when the original successfully activates the desired image.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redeploy failed Railway candidate s..."](https://github.com/rusty-auth/rustyauth/commit/9176900c89d40cac2517542cbec91ab972491b5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51624586)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->