### PR TITLE
fix: explicitly deploy updated Railway sources

### DIFF
--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -1,6 +1,7 @@
 import {
   configuredServiceImage,
   deploymentMatchesProfile,
+  imageReferenceDigest,
   matchingDeployment,
   normalizeDigest,
   parseDeployments,
@@ -36,6 +37,12 @@ function deployment(id: string, status: string, target = true): RailwayDeploymen
       imageDigest: `sha256:${"b".repeat(64)}`,
     },
   };
+}
+
+function pinnedDeploymentWithoutSeparateDigest(id: string, status: string): RailwayDeployment {
+  const candidate = deployment(id, status);
+  if (candidate.meta) delete candidate.meta.imageDigest;
+  return candidate;
 }
 
 function projectStatus(configuredImage = "ghcr.io/rusty-auth/rustyauth@sha256:older"): string {
@@ -86,6 +93,12 @@ Deno.test("deployment parsing and matching require the exact image and digest", 
   assertEquals(normalizeDigest(digest.toUpperCase()), digest);
   assertEquals(pinnedImageReference(image, digest), sourceImage);
   assertEquals(pinnedImageReference(`${image}@${digest}`, digest), sourceImage);
+  assertEquals(imageReferenceDigest(sourceImage), digest);
+  assertEquals(imageReferenceDigest(image), null);
+  assertEquals(
+    matchingDeployment([pinnedDeploymentWithoutSeparateDigest("pinned", "SUCCESS")], sourceImage, digest)?.id,
+    "pinned",
+  );
   assert(deploymentMatchesProfile(deployments[1], "realm"), "candidate policy did not match");
   assertEquals(configuredServiceImage(projectStatus(sourceImage), "production", "api"), sourceImage);
 });
@@ -95,6 +108,7 @@ Deno.test("a historical matching image is not mistaken for the active deployment
     JSON.stringify([deployment("current", "SUCCESS", false), deployment("historical", "SUCCESS")]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("current", "SUCCESS", false)]),
   ];
   let mutations = 0;
@@ -129,6 +143,7 @@ Deno.test("rollout waits for the exact digest to reach terminal success before h
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("queued", "QUEUED"), deployment("old", "SUCCESS", false)]),
     JSON.stringify([deployment("new", "DEPLOYING"), deployment("old", "SUCCESS", false)]),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
@@ -170,6 +185,7 @@ Deno.test("rollout waits for the exact digest to reach terminal success before h
   assertEquals(receipt.previousDeploymentId, "old");
   assertEquals(healthChecks, 1);
   assert(commands.some((args) => args[0] === "api"), "service update mutation was not invoked");
+  assert(commands.some((args) => args[0] === "redeploy"), "updated source was not explicitly deployed");
   const mutation = commands.find((args) => args[0] === "api");
   const variablesIndex = mutation?.indexOf("--variables") ?? -1;
   const variables = JSON.parse(variablesIndex >= 0 ? mutation?.[variablesIndex + 1] ?? "{}" : "{}") as {
@@ -185,6 +201,7 @@ Deno.test("a deployment receipt exists before a failing health check so rollback
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
   ];
   const runner: RailwayRunner = () =>
@@ -297,6 +314,7 @@ Deno.test("rollout fails closed on a terminal failed deployment", async () => {
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("failed", "FAILED")]),
   ];
   const runner: RailwayRunner = () =>

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -112,6 +112,11 @@ export function pinnedImageReference(image: string, digest: string): string {
   return `${repository}@${normalizedDigest}`;
 }
 
+export function imageReferenceDigest(image: string | undefined): string | null {
+  const match = image?.trim().match(/@(sha256:[0-9a-f]{64})$/i);
+  return match ? normalizeDigest(match[1]) : null;
+}
+
 export function serviceUpdateInput(
   profile: RailwayServiceProfile,
   image: string,
@@ -216,7 +221,9 @@ export function matchingDeployment(
 ): RailwayDeployment | undefined {
   return deployments.find((deployment) =>
     !excludedIds.has(deployment.id) &&
-    deployment.meta?.image === image && deployment.meta?.imageDigest?.toLowerCase() === digest
+    deployment.meta?.image === image &&
+    (deployment.meta?.imageDigest?.toLowerCase() === digest ||
+      imageReferenceDigest(deployment.meta?.image) === digest)
   );
 }
 
@@ -355,7 +362,7 @@ export async function rolloutRailwayImage(
     profile: options.profile,
     previousDeploymentId: previous?.id ?? null,
     previousImage: previous?.meta?.image ?? null,
-    previousDigest: previous?.meta?.imageDigest ?? null,
+    previousDigest: previous?.meta?.imageDigest ?? imageReferenceDigest(previous?.meta?.image),
     deploymentId: null,
     image: options.image,
     sourceImage,
@@ -381,9 +388,7 @@ export async function rolloutRailwayImage(
       options.environment,
       options.service,
     );
-    if (configuredImage === sourceImage) {
-      await runJson(runner, redeployArgs(options));
-    } else {
+    if (configuredImage !== sourceImage) {
       const update = JSON.parse(await runJson(runner, updateArgs(options, sourceImage))) as {
         data?: { serviceInstanceUpdate?: boolean };
         errors?: unknown[];
@@ -392,6 +397,7 @@ export async function rolloutRailwayImage(
         fail("Railway rejected the service image/configuration update");
       }
     }
+    await runJson(runner, redeployArgs(options));
     receipt.changed = true;
     await writeReceipt();
 

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -43,9 +43,10 @@ Deno.test("Railway candidates are immutable, signed and digest-verified", () => 
       "matchingDeployment(deployments, sourceImage, digest, baselineIds)",
       "pinnedImageReference(options.image, digest)",
       'candidate.status === "SUCCESS"',
-      "configuredImage === sourceImage",
+      "configuredImage !== sourceImage",
       '"redeploy"',
       '"--from-source"',
+      "await runJson(runner, redeployArgs(options));",
     ]
   ) assertIncludes(workflow + rollout, required);
   if (/tags:.*:latest/.test(workflow)) {


### PR DESCRIPTION
## Summary

- explicitly run `railway redeploy --from-source` after changing a service image/configuration
- keep the same redeploy path when the desired digest is already configured after a failed deployment
- accept Railway pinned-image deployment metadata when the digest is embedded in `meta.image` and `meta.imageDigest` is absent
- derive rollback digest evidence from the pinned image when Railway omits the separate field

## Live evidence

Run 31331693622 updated the API configured source to the signed digest but created no deployment. Railway status confirms the source update; the deployment list confirms no new deployment record. This patch makes deployment creation explicit.

## Validation

- `deno task railway:check`
- `deno task railway:test`
- `deno task release:test`
- `deno task ci:test`

All 27 tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR explicitly redeploys Railway services after updating their configured source and accepts pinned-image metadata when Railway omits a separate digest field.

- Adds digest extraction from pinned image references for deployment matching and rollback receipts.
- Runs `railway redeploy --from-source` after both unchanged and newly updated source configurations.
- Expands rollout and workflow tests for explicit redeployment and embedded digest metadata.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until a failed redeploy after a successful source update leaves a durable receipt that allows the workflow to restore the previous service configuration.

The source mutation can succeed before the newly added redeploy command throws, while the recovery receipt is written only afterward; the workflow then skips rollback and leaves partially applied Railway state.

**Files Needing Attention:** scripts/railway-rollout.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/railway-rollout.ts | Adds pinned-image digest fallback and explicit redeployment, but persists rollback evidence too late to recover when redeploy fails after a successful source update. |
| scripts/railway-rollout.test.ts | Extends matching and successful rollout coverage, but does not exercise failure of the new redeploy command after a successful source mutation. |
| scripts/railway-workflow.test.ts | Updates static workflow assertions to require explicit source redeployment and contains no independent defect. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Workflow
    participant Rollout
    participant Railway
    participant Receipt
    Workflow->>Rollout: Start image rollout
    Rollout->>Railway: Read deployments and configured source
    alt Source differs
        Rollout->>Railway: serviceInstanceUpdate(new pinned image)
        Railway-->>Rollout: Update accepted
    end
    Rollout->>Railway: redeploy --from-source
    alt Redeploy succeeds
        Railway-->>Rollout: Request accepted
        Rollout->>Receipt: "Persist changed=true and previous state"
        Rollout->>Railway: Poll exact image and digest
    else Redeploy command fails
        Railway--xRollout: Nonzero exit
        Rollout--xWorkflow: Error before receipt write
        Workflow->>Receipt: Look for rollback receipt
        Receipt-->>Workflow: Missing
        Note over Workflow,Railway: Rollback skips the already-updated service
    end
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-railway-image-normalization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-railway-image-normalization%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Frailway-rollout.ts%3A400-402%0A**Redeploy%20failure%20loses%20rollback%20state**%0A%0AWhen%20the%20service%20source%20update%20succeeds%20but%20%60railway%20redeploy%60%20exits%20unsuccessfully%2C%20%60runJson%60%20throws%20before%20the%20changed%20receipt%20is%20persisted%2C%20causing%20the%20workflow%20rollback%20step%20to%20skip%20the%20already-modified%20service%20and%20leave%20it%20configured%20for%20the%20new%20image%20without%20a%20confirmed%20deployment%20or%20restoration%20of%20the%20previous%20source.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Frailway-rollout.ts%3A400-402%0A**Redeploy%20failure%20loses%20rollback%20state**%0A%0AWhen%20the%20service%20source%20update%20succeeds%20but%20%60railway%20redeploy%60%20exits%20unsuccessfully%2C%20%60runJson%60%20throws%20before%20the%20changed%20receipt%20is%20persisted%2C%20causing%20the%20workflow%20rollback%20step%20to%20skip%20the%20already-modified%20service%20and%20leave%20it%20configured%20for%20the%20new%20image%20without%20a%20confirmed%20deployment%20or%20restoration%20of%20the%20previous%20source.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/railway-rollout.ts:400-402
**Redeploy failure loses rollback state**

When the service source update succeeds but `railway redeploy` exits unsuccessfully, `runJson` throws before the changed receipt is persisted, causing the workflow rollback step to skip the already-modified service and leave it configured for the new image without a confirmed deployment or restoration of the previous source.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: explicitly deploy updated Railway s..."](https://github.com/rusty-auth/rustyauth/commit/af045921b72157e0f1ca3cc75875e00b60317b19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51625354)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->