### PR TITLE
fix: configure Railway trusted proxy boundary

### DIFF
--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -275,6 +275,7 @@ jobs:
             --environment "${RAILWAY_ENVIRONMENT_ID}" \
             --service "${RAILWAY_API_SERVICE_ID}" \
             --skip-deploys --json \
+            "AUTH_TRUSTED_PROXY_HOPS=1" \
             "AUTH_ISSUER=${dashboard_url}" \
             "WEBAUTHN_RP_ORIGIN=${dashboard_url}" \
             "WEBAUTHN_RP_ID=${dashboard_host}" >/dev/null

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -66,6 +66,7 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
   for (const required of ["/healthz", "/readyz", "retention-days: 90"]) {
     assertIncludes(workflow, required);
   }
+  assertIncludes(workflow, '"AUTH_TRUSTED_PROXY_HOPS=1"');
 });
 
 Deno.test("a partial Railway rollout restores services and browser origin in reverse order", () => {


### PR DESCRIPTION
## Summary

- set `AUTH_TRUSTED_PROXY_HOPS=1` for the Railway API before production rollout
- keep deploys suppressed while aligning runtime configuration so the verified image rollout remains the only deployment trigger
- lock the production proxy boundary into the Railway workflow regression test

## Why 1

Railway terminates TLS in front of the RustyAuth container, so one trusted proxy is the explicit production-safe setting. The API intentionally refuses to start when this is omitted.

## Live evidence

Failed deployment `cf900715-317d-49cf-98c7-c0e99c49085d` exited during startup because this value was absent. It is now set live with `--skip-deploys` and this PR makes it durable in main-branch automation.

## Validation

- `deno task railway:test`
- `deno task ci:test`
- `deno task release:test`

All 27 tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR durably configures Railway’s production API to trust one proxy hop before deploying the verified image.

- Adds `AUTH_TRUSTED_PROXY_HOPS=1` to the API-scoped, deployment-suppressed Railway variable update.
- Adds a workflow regression assertion for the required setting, although the assertion is not scoped to the relevant command.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking weakness in how the new regression test verifies the workflow configuration.

The production workflow sets the required value on the intended API service before deployment, but the test only proves that the text exists somewhere in the workflow and could miss a future placement or ordering regression.

**Files Needing Attention:** scripts/railway-workflow.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/railway-production.yml | Correctly adds the required trusted-proxy setting to the API service variable command before rollout without triggering an intermediate deployment. |
| scripts/railway-workflow.test.ts | Adds regression coverage, but its whole-file substring assertion can pass when the setting is no longer applied to the API before deployment. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-railway-proxy-hops%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-railway-proxy-hops%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Frailway-workflow.test.ts%3A69%0A**Unscoped%20workflow%20regression%20assertion**%0A%0AThis%20whole-file%20substring%20assertion%20passes%20when%20%60AUTH_TRUSTED_PROXY_HOPS%3D1%60%20appears%20in%20a%20comment%2C%20rollback%20block%2C%20another%20service%20command%2C%20or%20a%20step%20after%20API%20deployment%2C%20so%20CI%20can%20miss%20removal%20of%20the%20required%20setting%20from%20the%20pre-deployment%20API%20command%20and%20provide%20false%20assurance%20against%20the%20production%20startup%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Frailway-workflow.test.ts%3A69%0A**Unscoped%20workflow%20regression%20assertion**%0A%0AThis%20whole-file%20substring%20assertion%20passes%20when%20%60AUTH_TRUSTED_PROXY_HOPS%3D1%60%20appears%20in%20a%20comment%2C%20rollback%20block%2C%20another%20service%20command%2C%20or%20a%20step%20after%20API%20deployment%2C%20so%20CI%20can%20miss%20removal%20of%20the%20required%20setting%20from%20the%20pre-deployment%20API%20command%20and%20provide%20false%20assurance%20against%20the%20production%20startup%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/railway-workflow.test.ts:69
**Unscoped workflow regression assertion**

This whole-file substring assertion passes when `AUTH_TRUSTED_PROXY_HOPS=1` appears in a comment, rollback block, another service command, or a step after API deployment, so CI can miss removal of the required setting from the pre-deployment API command and provide false assurance against the production startup failure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: configure Railway trusted proxy bou..."](https://github.com/rusty-auth/rustyauth/commit/fbfda552905c65cba099501d9b83505214da7af2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51625865)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->