### PR TITLE
fix: gate Railway rollout on live backup

### DIFF
--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -311,6 +311,26 @@ jobs:
           --health-url "${RAILWAY_API_URL%/}/healthz"
           --health-url "${RAILWAY_API_URL%/}/readyz"
           --receipt "${RUNNER_TEMP}/railway-receipts/api.json"
+      - name: Require a fresh verified recovery point
+        run: |
+          deployment_id="$(jq -r '.deploymentId' "${RUNNER_TEMP}/railway-receipts/api.json")"
+          for attempt in {1..12}; do
+            logs="$(railway logs "${deployment_id}" \
+              --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT_ID}" \
+              --service "${RAILWAY_API_SERVICE_ID}" \
+              --lines 200 --json || true)"
+            if jq --slurp --exit-status \
+              'any(.[]; (.message // "") | contains("encrypted backup created and verified"))' \
+              <<<"${logs}" >/dev/null; then
+              exit 0
+            fi
+            if [[ "${attempt}" -lt 12 ]]; then
+              sleep 5
+            fi
+          done
+          echo "::error::candidate did not create and verify a fresh encrypted backup"
+          exit 1
       - name: Deploy dashboard
         run: >-
           deno run --allow-env --allow-net --allow-run --allow-write="${RUNNER_TEMP}/railway-receipts"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,13 +96,13 @@ digest in a terminal `SUCCESS` deployment. Mutable `latest` tags are never used 
 
 Rollouts are serialized across the state boundaries:
 
-1. The realm API creates and verifies a fresh recovery point and then runs the target image's
-   `rustyauth doctor` as Railway pre-deploy commands, then reaches
-   `/healthz` and `/readyz` on the application API origin.
+1. The realm API runs the target image's read-only `rustyauth doctor` pre-deploy command, reaches `/healthz`
+   and `/readyz`, and must then log a fresh encrypted, read-back-verified recovery point from its own
+   single-writer scheduler.
 2. The stateless dashboard deploys and reaches both probes through its public origin, including its private
    upstream readiness check.
-3. Private SableDB is replaced without recreating its volume, after which both API and dashboard readiness
-   are checked again.
+3. Private SableDB is replaced without recreating its volume, after which both API and dashboard readiness are
+   checked again.
 
 Before the first mutation, the workflow records the active deployment and browser-origin configuration. A
 later deployment or readiness failure restores every completed service in reverse order, restores the prior

--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -69,10 +69,7 @@ Deno.test("Railway service profiles preserve the one-writer and readiness polici
     numReplicas: 1,
     overlapSeconds: 0,
     drainingSeconds: 25,
-    preDeployCommand: [
-      "/usr/local/bin/rustyauth backup create",
-      "/usr/local/bin/rustyauth doctor",
-    ],
+    preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
     restartPolicyType: "ON_FAILURE",
     restartPolicyMaxRetries: 10,
   });

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -131,10 +131,7 @@ export function serviceUpdateInput(
         numReplicas: 1,
         overlapSeconds: 0,
         drainingSeconds: 25,
-        preDeployCommand: [
-          "/usr/local/bin/rustyauth backup create",
-          "/usr/local/bin/rustyauth doctor",
-        ],
+        preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
         restartPolicyType: "ON_FAILURE",
         restartPolicyMaxRetries: 10,
       };

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -71,7 +71,13 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
   assertIncludes(workflow, '"AUTH_TRUSTED_PROXY_HOPS=1"');
   assertIncludes(workflow, '"AUTH_BACKUP_STORAGE_PROFILE=portable"');
   assertIncludes(workflow, '"AUTH_BACKUP_SSE=provider"');
-  assertIncludes(rollout, '"/usr/local/bin/rustyauth backup create"');
+  assertIncludes(workflow, "name: Require a fresh verified recovery point");
+  assertIncludes(workflow, "encrypted backup created and verified");
+  assertOrdered(workflow, [
+    "name: Deploy realm API",
+    "name: Require a fresh verified recovery point",
+    "name: Deploy dashboard",
+  ]);
 });
 
 Deno.test("a partial Railway rollout restores services and browser origin in reverse order", () => {

--- a/src/backup/scheduler.rs
+++ b/src/backup/scheduler.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 use tracing::error;
 
 use crate::{
-    config::KeyRing,
+    config::{BackupStorageProfile, KeyRing},
     store::{Store, now},
 };
 
@@ -30,6 +30,7 @@ pub struct BackupStatus {
     pub rpo_seconds: u64,
     pub retention_days: u64,
     pub storage_profile: String,
+    pub profile_transition_pending: bool,
     pub overdue: bool,
     pub alerting: bool,
 }
@@ -55,6 +56,19 @@ impl BackupStore {
             .map(|value| serde_json::from_str(&value).context("decode persisted backup status"))
             .transpose()?
             .unwrap_or_default();
+        status.profile_transition_pending =
+            storage_profile_transition_pending(&status.storage_profile, self.storage_profile);
+        if status.profile_transition_pending {
+            // A failure under one provider contract says nothing about the new
+            // contract. Keep the transition visible, but let the candidate start
+            // so its immediate scheduler tick can establish the first recovery
+            // point under the selected profile.
+            status.running = false;
+            status.last_attempt_at = None;
+            status.last_success_at = None;
+            status.last_object_key = None;
+            status.consecutive_failures = 0;
+        }
         status.rpo_seconds = self.rpo_seconds;
         status.retention_days = self.retention_days;
         status.storage_profile = self.storage_profile.as_str().to_owned();
@@ -81,6 +95,7 @@ impl BackupStore {
             status.rpo_seconds = self.rpo_seconds;
             status.retention_days = self.retention_days;
             status.storage_profile = self.storage_profile.as_str().to_owned();
+            status.profile_transition_pending = false;
             self.evaluate_health(&mut status);
             self.persist_status(store, &status).await;
         }
@@ -181,5 +196,44 @@ impl BackupStore {
                 }
             }
         }
+    }
+}
+
+fn storage_profile_transition_pending(
+    stored_profile: &str,
+    current_profile: BackupStorageProfile,
+) -> bool {
+    let current_profile = current_profile.as_str();
+    match stored_profile {
+        // Status written before profiles existed represented the immutable
+        // contract. Preserve its failures unless this deployment explicitly
+        // moves to portable storage.
+        "" => current_profile == "portable",
+        stored_profile => stored_profile != current_profile,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_profile_transitions_are_explicit_without_erasing_legacy_strict_failures() {
+        assert!(!storage_profile_transition_pending(
+            "",
+            BackupStorageProfile::Immutable
+        ));
+        assert!(storage_profile_transition_pending(
+            "",
+            BackupStorageProfile::Portable
+        ));
+        assert!(storage_profile_transition_pending(
+            "portable",
+            BackupStorageProfile::Immutable
+        ));
+        assert!(!storage_profile_transition_pending(
+            "portable",
+            BackupStorageProfile::Portable
+        ));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -775,6 +775,7 @@ async fn doctor(
                 "rpoSeconds": status.rpo_seconds,
                 "retentionDays": status.retention_days,
                 "storageProfile": status.storage_profile,
+                "profileTransitionPending": status.profile_transition_pending,
                 "overdue": status.overdue,
                 "alerting": status.alerting,
             })


### PR DESCRIPTION
## What changed
- keep Railway pre-deploy to the single supported read-only `rustyauth doctor` command
- make a configured backup storage-profile transition explicit so a stale failure from the prior provider contract does not prevent the candidate from starting
- require the exact API candidate to create and read-back verify a fresh encrypted recovery point before the dashboard or SableDB can roll out

## Why
Railway rejected the two-command `preDeployCommand` update. Running `backup create` before cutover would also contend with the live API writer lease. The API scheduler is the correct single writer and performs its first backup immediately.

## Verified
- `cargo test --locked --lib` (192 passed, 12 integration-only ignored)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `deno task railway:test` (13 passed)
- `deno task ci:test` (11 passed)
- `deno task docs:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Railway backup verification from the API pre-deploy command to a post-deployment log gate and exposes backup storage-profile transitions in persisted status and doctor output. The new gate currently runs before the scheduler can produce the log it requires.
- Keeps Railway API pre-deploy limited to the read-only `rustyauth doctor` command.
- Clears obsolete backup failure state when the configured storage profile changes.
- Polls candidate deployment logs for a newly created, read-back-verified encrypted backup before continuing the rollout.
- Updates deployment documentation and Railway workflow tests.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the recovery-point gate is aligned with the scheduler, because production API rollouts will fail before the required backup can run.

The workflow allows roughly 60 seconds for a verification log, while backup creation begins only after a scheduler interval whose minimum is five minutes and whose default is six hours.

**Files Needing Attention:** .github/workflows/railway-production.yml and src/backup/scheduler.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/railway-production.yml | Adds the recovery-point gate, but its 60-second window expires before the scheduler's first interval-driven backup. |
| src/backup/scheduler.rs | Adds explicit storage-profile transition handling; its existing interval-first scheduler behavior conflicts with the workflow's immediate-backup assumption. |
| scripts/railway-rollout.ts | Correctly reduces the API pre-deploy command list to the supported read-only doctor invocation. |
| src/cli.rs | Exposes the derived profile-transition state in doctor JSON without breaking legacy status deserialization. |
| scripts/railway-workflow.test.ts | Checks workflow ordering and message presence but does not validate that scheduler timing can satisfy the new gate. |
| scripts/railway-rollout.test.ts | Updates the expected API service profile to the single doctor pre-deploy command. |
| docs/DEPLOYMENT.md | Documents an immediate scheduler-created recovery point that the current interval-driven scheduler does not produce. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deploy realm API] --> B[Health and readiness pass]
    B --> C[Poll logs for up to 60 seconds]
    C --> D{Verification message found?}
    D -- No --> E[Fail rollout]
    D -- Yes --> F[Deploy dashboard]
    G[Backup scheduler starts] --> H[Wait configured interval]
    H --> I[Create and verify backup]
    I --> J[Emit verification message]
    J -. occurs after polling window .-> C
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-railway-predeploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-railway-predeploy%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A317-331%0A**Backup%20gate%20precedes%20scheduler%20tick**%0A%0AWhen%20the%20API%20uses%20any%20supported%20backup%20interval%2C%20this%20step%20waits%20only%20about%2060%20seconds%20for%20a%20verification%20message%20even%20though%20the%20scheduler%20does%20not%20create%20its%20first%20backup%20until%20at%20least%20five%20minutes%20later%2C%20causing%20healthy%20production%20rollouts%20to%20fail%20before%20the%20dashboard%20and%20SableDB%20deploy.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A317-331%0A**Backup%20gate%20precedes%20scheduler%20tick**%0A%0AWhen%20the%20API%20uses%20any%20supported%20backup%20interval%2C%20this%20step%20waits%20only%20about%2060%20seconds%20for%20a%20verification%20message%20even%20though%20the%20scheduler%20does%20not%20create%20its%20first%20backup%20until%20at%20least%20five%20minutes%20later%2C%20causing%20healthy%20production%20rollouts%20to%20fail%20before%20the%20dashboard%20and%20SableDB%20deploy.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/railway-production.yml:317-331
**Backup gate precedes scheduler tick**

When the API uses any supported backup interval, this step waits only about 60 seconds for a verification message even though the scheduler does not create its first backup until at least five minutes later, causing healthy production rollouts to fail before the dashboard and SableDB deploy.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gate Railway rollout on live backup"](https://github.com/rusty-auth/rustyauth/commit/ba59a99cad114952fc0102e119c7800e9d3e6594) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51631470)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->