### PR TITLE
fix: make Railway handoff backup-safe

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,9 +96,9 @@ digest in a terminal `SUCCESS` deployment. Mutable `latest` tags are never used 
 
 Rollouts are serialized across the state boundaries:
 
-1. The realm API runs the target image's read-only `rustyauth doctor` pre-deploy command, reaches `/healthz`
-   and `/readyz`, and must then log a fresh encrypted, read-back-verified recovery point from its own
-   single-writer scheduler.
+1. The realm API records the active successful deployment, stops that exact one-writer service, and runs the
+   target image's `rustyauth backup create` pre-deploy command. The fresh encrypted recovery point must pass
+   read-back verification before the replacement can start and reach `/healthz` and `/readyz`.
 2. The stateless dashboard deploys and reaches both probes through its public origin, including its private
    upstream readiness check.
 3. Private SableDB is replaced without recreating its volume, after which both API and dashboard readiness are
@@ -368,14 +368,12 @@ namespace's SableDB writer lease. It renews the 60-second lease every 10 seconds
 fails or the ownership token changes. Multi-key operations use SableDB atomic pipelines and compound mutations
 also use a process-local mutex; active/active mutation has not been qualified and is unsupported.
 
-`railway.json` pins `numReplicas: 1` and `overlapSeconds: 0` so a scale-up or a rolling deploy cannot silently
-start a second writer. This narrows the window rather than removing it: `drainingSeconds` (25) is the time the
-outgoing process has between `SIGTERM` and `SIGKILL`, and for that period the old process is still finishing
-in-flight requests while the new one is live. It stops accepting new work at `SIGTERM`, so the overlap covers
-requests already in progress, not new mutations — but it is not zero. Treat a deploy as a short window in
-which the outgoing process may still be draining. The replacement cannot serve while the old process retains
-the writer lease; the platform may therefore need to wait up to the lease TTL before the new instance starts.
-Avoid deploying during a bulk migration and configure health/restart policy to tolerate that bounded wait.
+`railway.json` pins `numReplicas: 1` and `overlapSeconds: 0`, and the production workflow performs an explicit
+stop-before-start handoff. Railway otherwise keeps the old deployment live until its replacement becomes
+ready, which deadlocks a correctly fenced one-writer service. The workflow writes the rollback receipt first,
+stops the serving deployment, creates and verifies a backup in the target image's pre-deploy container, and
+then starts the replacement. This creates a bounded maintenance window but never weakens the writer lease.
+Avoid deploying during a bulk migration.
 
 Raising `numReplicas` above 1 is not supported in this version. A second process using the same namespace
 fails startup while the lease is owned, and a process that loses ownership stops the server. The lease is a

--- a/scripts/railway-rollout.test.ts
+++ b/scripts/railway-rollout.test.ts
@@ -69,7 +69,7 @@ Deno.test("Railway service profiles preserve the one-writer and readiness polici
     numReplicas: 1,
     overlapSeconds: 0,
     drainingSeconds: 25,
-    preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
+    preDeployCommand: ["/usr/local/bin/rustyauth backup create"],
     restartPolicyType: "ON_FAILURE",
     restartPolicyMaxRetries: 10,
   });
@@ -108,6 +108,7 @@ Deno.test("a historical matching image is not mistaken for the active deployment
     JSON.stringify([deployment("current", "SUCCESS", false), deployment("historical", "SUCCESS")]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    "",
     JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("current", "SUCCESS", false)]),
   ];
@@ -143,6 +144,7 @@ Deno.test("rollout waits for the exact digest to reach terminal success before h
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    "",
     JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("queued", "QUEUED"), deployment("old", "SUCCESS", false)]),
     JSON.stringify([deployment("new", "DEPLOYING"), deployment("old", "SUCCESS", false)]),
@@ -185,6 +187,9 @@ Deno.test("rollout waits for the exact digest to reach terminal success before h
   assertEquals(receipt.previousDeploymentId, "old");
   assertEquals(healthChecks, 1);
   assert(commands.some((args) => args[0] === "api"), "service update mutation was not invoked");
+  const down = commands.findIndex((args) => args[0] === "down");
+  const redeployIndex = commands.findIndex((args) => args[0] === "redeploy");
+  assert(down >= 0 && down < redeployIndex, "realm writer handoff did not precede deployment");
   assert(commands.some((args) => args[0] === "redeploy"), "updated source was not explicitly deployed");
   const mutation = commands.find((args) => args[0] === "api");
   const variablesIndex = mutation?.indexOf("--variables") ?? -1;
@@ -201,6 +206,7 @@ Deno.test("a deployment receipt exists before a failing health check so rollback
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    "",
     JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("new", "SUCCESS"), deployment("old", "SUCCESS", false)]),
   ];
@@ -314,6 +320,7 @@ Deno.test("rollout fails closed on a terminal failed deployment", async () => {
     JSON.stringify([deployment("old", "SUCCESS", false)]),
     projectStatus(),
     JSON.stringify({ data: { serviceInstanceUpdate: true } }),
+    "",
     JSON.stringify({ id: "requested" }),
     JSON.stringify([deployment("failed", "FAILED")]),
   ];

--- a/scripts/railway-rollout.ts
+++ b/scripts/railway-rollout.ts
@@ -131,7 +131,7 @@ export function serviceUpdateInput(
         numReplicas: 1,
         overlapSeconds: 0,
         drainingSeconds: 25,
-        preDeployCommand: ["/usr/local/bin/rustyauth doctor"],
+        preDeployCommand: ["/usr/local/bin/rustyauth backup create"],
         restartPolicyType: "ON_FAILURE",
         restartPolicyMaxRetries: 10,
       };
@@ -297,6 +297,19 @@ function redeployArgs(options: RailwayRolloutOptions): string[] {
   ];
 }
 
+function downArgs(options: RailwayRolloutOptions): string[] {
+  return [
+    "down",
+    "--project",
+    options.project,
+    "--environment",
+    options.environment,
+    "--service",
+    options.service,
+    "--yes",
+  ];
+}
+
 function updateArgs(options: RailwayRolloutOptions, sourceImage: string): string[] {
   const variables = {
     serviceId: options.service,
@@ -352,7 +365,10 @@ export async function rolloutRailwayImage(
   const digest = normalizeDigest(options.digest);
   const sourceImage = pinnedImageReference(options.image, digest);
   const baseline = parseDeployments(await runJson(runner, deploymentListArgs(options)));
-  const previous = baseline[0];
+  // Failed attempts may be newer than the deployment that is actually serving.
+  // The newest successful deployment is the rollback target; using baseline[0]
+  // can select a failed image and make recovery fail a second time.
+  const previous = baseline.find((deployment) => deployment.status === "SUCCESS");
   const current = previous && matchingDeployment([previous], sourceImage, digest);
 
   const receipt: RailwayRolloutReceipt = {
@@ -397,9 +413,17 @@ export async function rolloutRailwayImage(
         fail("Railway rejected the service image/configuration update");
       }
     }
-    await runJson(runner, redeployArgs(options));
     receipt.changed = true;
     await writeReceipt();
+
+    // Railway keeps the old deployment alive until its replacement is ready,
+    // even with overlapSeconds=0. A RustyAuth realm intentionally refuses to
+    // start while that old process owns the one-writer lease, so perform an
+    // explicit, receipt-backed handoff before starting the replacement.
+    if (options.profile === "realm" && previous) {
+      await runJson(runner, downArgs(options));
+    }
+    await runJson(runner, redeployArgs(options));
 
     const baselineIds = new Set(baseline.map((existing) => existing.id));
     const deadline = now().getTime() + options.timeoutMs;

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -71,6 +71,8 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
   assertIncludes(workflow, '"AUTH_TRUSTED_PROXY_HOPS=1"');
   assertIncludes(workflow, '"AUTH_BACKUP_STORAGE_PROFILE=portable"');
   assertIncludes(workflow, '"AUTH_BACKUP_SSE=provider"');
+  assertIncludes(rollout, '"/usr/local/bin/rustyauth backup create"');
+  assertIncludes(rollout, '"down"');
   assertIncludes(workflow, "name: Require a fresh verified recovery point");
   assertIncludes(workflow, "encrypted backup created and verified");
   assertOrdered(workflow, [

--- a/src/backup/snapshot.rs
+++ b/src/backup/snapshot.rs
@@ -225,7 +225,7 @@ impl BackupSnapshot {
         for record in &self.records {
             let family = record_family(&record.key)?;
             *index.families.entry(family.clone()).or_insert(0) += 1;
-            if family != "session" && record.expires_at.is_some() {
+            if !record_family_allows_expiry(&family) && record.expires_at.is_some() {
                 bail!(
                     "durable backup record {} unexpectedly has an expiry",
                     record.key
@@ -522,6 +522,26 @@ impl BackupSnapshot {
                         bail!("backup contains duplicate Fleet audit records");
                     }
                 }
+                "event-min-sequence"
+                | "invitation"
+                | "invitation-code"
+                | "webhook"
+                | "webhook-cursor"
+                | "webhook-delivery"
+                | "webhook-delivery-event"
+                | "fleet-assignment-epoch"
+                | "fleet-analytics-bucket"
+                | "fleet-analytics-policy"
+                | "fleet-analytics-policy-idempotency"
+                | "fleet-analytics-quarantine"
+                | "fleet-analytics-ingestion-audit"
+                | "fleet-analytics-operator-audit"
+                | "fleet-analytics-maintenance-audit"
+                | "fleet-analytics-manifest"
+                | "analytics-projector-cursor"
+                | "analytics-closure-cursor"
+                | "analytics-bucket"
+                | "analytics-outbox" => {}
                 _ => unreachable!("record_family returns known families"),
             }
         }
@@ -553,6 +573,17 @@ impl BackupSnapshot {
         }
         Ok(())
     }
+}
+
+fn record_family_allows_expiry(family: &str) -> bool {
+    matches!(
+        family,
+        "session"
+            | "remote-mutation"
+            | "fleet-analytics-quarantine"
+            | "fleet-analytics-ingestion-audit"
+            | "fleet-analytics-maintenance-audit"
+    )
 }
 
 #[derive(Default)]
@@ -1009,6 +1040,9 @@ fn record_family(key: &str) -> Result<String> {
     if key == "auth:event-sequence" {
         return Ok("event-sequence".into());
     }
+    if key == "auth:event-min-sequence" {
+        return Ok("event-min-sequence".into());
+    }
     if key == KEYSET_KEY {
         return Ok("keyset".into());
     }
@@ -1022,6 +1056,12 @@ fn record_family(key: &str) -> Result<String> {
         ("auth:credential:", "credential-index"),
         ("auth:session:", "session"),
         ("auth:event:", "event"),
+        ("auth:invitation:", "invitation"),
+        ("auth:invitation-code:", "invitation-code"),
+        ("auth:webhook:", "webhook"),
+        ("auth:webhook-cursor:", "webhook-cursor"),
+        ("auth:webhook-delivery:", "webhook-delivery"),
+        ("auth:webhook-delivery-event:", "webhook-delivery-event"),
         ("auth:operator:", "operator"),
         ("auth:service-account:", "service-account"),
         ("auth:service-credential:", "service-credential"),
@@ -1038,11 +1078,40 @@ fn record_family(key: &str) -> Result<String> {
         ("fleet:role-binding:", "fleet-role-binding"),
         ("fleet:role-binding-subject:", "fleet-role-binding-subject"),
         ("fleet:idempotency:", "fleet-idempotency"),
+        ("fleet:assignment-epoch:", "fleet-assignment-epoch"),
         ("fleet:audit:", "fleet-audit"),
+        ("fleet:analytics-bucket:", "fleet-analytics-bucket"),
+        ("fleet:analytics-policy:", "fleet-analytics-policy"),
+        (
+            "fleet:analytics-policy-idempotency:",
+            "fleet-analytics-policy-idempotency",
+        ),
+        ("fleet:analytics-quarantine:", "fleet-analytics-quarantine"),
+        (
+            "fleet:analytics-ingestion-audit:",
+            "fleet-analytics-ingestion-audit",
+        ),
+        (
+            "fleet:analytics-operator-audit:",
+            "fleet-analytics-operator-audit",
+        ),
+        (
+            "fleet:analytics-maintenance-audit:",
+            "fleet-analytics-maintenance-audit",
+        ),
+        ("fleet:analytics-manifest:", "fleet-analytics-manifest"),
+        ("analytics:bucket:", "analytics-bucket"),
+        ("analytics:outbox:", "analytics-outbox"),
     ] {
         if key.starts_with(prefix) && key.len() > prefix.len() {
             return Ok(family.into());
         }
+    }
+    if key == "analytics:projector-cursor" {
+        return Ok("analytics-projector-cursor".into());
+    }
+    if key == "analytics:closure-cursor" {
+        return Ok("analytics-closure-cursor".into());
     }
     bail!("backup contains unsupported key {key}")
 }
@@ -1195,6 +1264,30 @@ fn rehash(snapshot: &mut BackupSnapshot) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn durable_analytics_records_are_covered_by_the_backup_manifest() {
+        let snapshot = BackupSnapshot::from_records(
+            "tenant-a",
+            1_000,
+            vec![
+                StoreRecord {
+                    key: "analytics:bucket:00000000001786127100".into(),
+                    value: "bucket".into(),
+                    expires_at: None,
+                },
+                StoreRecord {
+                    key: KEYSET_KEY.into(),
+                    value: keyset_value(),
+                    expires_at: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.manifest.key_families["analytics-bucket"], 1);
+        snapshot.validate("tenant-a").unwrap();
+    }
 
     #[test]
     fn compact_binary_snapshot_round_trips_without_json_field_names() {


### PR DESCRIPTION
## What changed
- cover local and fleet analytics key families in V3 backup snapshot manifests, including the retained expiring audit families
- select the newest successful Railway deployment as the rollback target instead of the newest failed attempt
- write the rollback receipt and stop the old realm before starting its replacement, preserving the one-writer fence
- use the one supported pre-deploy command for a fresh encrypted, read-back-verified backup

## Production evidence
- reproduced the failure against production: `backup contains unsupported key analytics:bucket:...`
- fixed binary created and verified V3 snapshot `f6b829f0-838d-4bb9-81ff-d9f1a1c44898` with 8 records in the production Railway bucket
- production API restored and `/readyz` is green

## Verified
- `cargo test --locked --lib` (193 passed, 12 integration-only ignored)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `deno task railway:test` (13 passed)
- `deno task ci:test` (11 passed)
- `deno task docs:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Railway realm deployments backup-safe by stopping the previous writer before redeployment, recording the newest successful deployment for rollback, and running a verified backup as the pre-deploy command. It also expands V3 snapshot manifests to cover local and fleet analytics, invitations, webhooks, assignment epochs, and retained expiring audit families.
- Selects the newest successful Railway deployment as the rollback baseline.
- Writes the rollback receipt before performing the realm stop-before-start handoff.
- Replaces the realm doctor pre-deploy command with encrypted backup creation and verification.
- Extends snapshot family classification and expiry handling for additional durable and retained records.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking defects identified.

The changed rollout sequence preserves rollback metadata before stopping the old writer, and the expanded snapshot classifications match the repository's current key and expiry behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/railway-rollout.ts | Selects the latest successful rollback target, persists the receipt, stops the realm writer, and then redeploys the pinned replacement. |
| src/backup/snapshot.rs | Adds snapshot classification for analytics and related key families while permitting expiry only for known retained families. |
| scripts/railway-rollout.test.ts | Updates rollout fixtures and verifies that the realm stop occurs before redeployment. |
| scripts/railway-workflow.test.ts | Extends workflow assertions to cover backup creation and the explicit service handoff. |
| docs/DEPLOYMENT.md | Documents the receipt-backed stop-before-start deployment sequence and its bounded maintenance window. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Production workflow
    participant R as Railway rollout
    participant O as Old realm
    participant P as Pre-deploy container
    participant N as New realm
    W->>R: Deploy pinned image digest
    R->>R: Select newest successful deployment
    R->>R: Write rollback receipt
    R->>O: railway down
    O-->>R: Writer stopped / lease released
    R->>P: railway redeploy
    P->>P: Create encrypted backup
    P->>P: Read-back verify snapshot
    P-->>R: Pre-deploy succeeds
    R->>N: Start replacement
    R->>N: Verify healthz and readyz
    R-->>W: Persist successful receipt
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make Railway handoff backup-safe"](https://github.com/rusty-auth/rustyauth/commit/b0ac29bbd1037034ca0343dcda81177b910e939b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51636412)</sub>

<!-- /greptile_comment -->