### PR TITLE
fix: verify Railway backup receipts

### DIFF
--- a/.github/workflows/railway-production.yml
+++ b/.github/workflows/railway-production.yml
@@ -295,6 +295,7 @@ jobs:
             "AUTH_TRUSTED_PROXY_HOPS=1" \
             "AUTH_BACKUP_STORAGE_PROFILE=portable" \
             "AUTH_BACKUP_SSE=provider" \
+            "RUST_LOG=rustyauth=info,tower_http=info" \
             "AUTH_ISSUER=${dashboard_url}" \
             "WEBAUTHN_RP_ORIGIN=${dashboard_url}" \
             "WEBAUTHN_RP_ID=${dashboard_host}" >/dev/null
@@ -320,8 +321,13 @@ jobs:
               --environment "${RAILWAY_ENVIRONMENT_ID}" \
               --service "${RAILWAY_API_SERVICE_ID}" \
               --lines 200 --json || true)"
-            if jq --slurp --exit-status \
-              'any(.[]; (.message // "") | contains("encrypted backup created and verified"))' \
+            if jq --slurp --exit-status '
+              any(.[]; (.message // "") | contains("encrypted backup created and verified")) or
+              (
+                any(.[]; (.message // "") | contains("\"formatVersion\": 3")) and
+                any(.[]; (.message // "") | contains("\"objectKey\": \"rustyauth-backups/v3/")) and
+                any(.[]; (.message // "") | contains("\"storageProfile\": \"portable\""))
+              )' \
               <<<"${logs}" >/dev/null; then
               exit 0
             fi

--- a/scripts/railway-workflow.test.ts
+++ b/scripts/railway-workflow.test.ts
@@ -71,10 +71,13 @@ Deno.test("Railway rollout is serialized across every stateful boundary", () => 
   assertIncludes(workflow, '"AUTH_TRUSTED_PROXY_HOPS=1"');
   assertIncludes(workflow, '"AUTH_BACKUP_STORAGE_PROFILE=portable"');
   assertIncludes(workflow, '"AUTH_BACKUP_SSE=provider"');
+  assertIncludes(workflow, '"RUST_LOG=rustyauth=info,tower_http=info"');
   assertIncludes(rollout, '"/usr/local/bin/rustyauth backup create"');
   assertIncludes(rollout, '"down"');
   assertIncludes(workflow, "name: Require a fresh verified recovery point");
   assertIncludes(workflow, "encrypted backup created and verified");
+  assertIncludes(workflow, '"formatVersion\\": 3"');
+  assertIncludes(workflow, "rustyauth-backups/v3/");
   assertOrdered(workflow, [
     "name: Deploy realm API",
     "name: Require a fresh verified recovery point",


### PR DESCRIPTION
## What changed
- align the production tracing filter with the current `rustyauth` crate target
- accept either the tracing success event or the structured V3 portable backup receipt from the exact deployment logs

The pre-deploy command exits successfully only after upload, decrypt, manifest validation and read-after-write verification. Railway emitted the receipt but the legacy `passkey_auth_service` filter suppressed the tracing event.

## Verified
- `deno task railway:check`
- `deno task railway:test` (13 passed)
- actionlint v1.7.12

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates Railway production logging so backup success events are visible and permits the deployment gate to recognize the structured V3 portable-backup receipt.
- Sets the production `RUST_LOG` filter to the current `rustyauth` and `tower_http` targets.
- Extends recovery-point verification to recognize the V3 receipt fields.
- Adds workflow assertions covering the new filter and receipt format.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking rollback-fidelity issue for customized production logging configuration.

Backup verification remains scoped to the candidate deployment, while the only accepted concern is that a failed rollout leaves the newly assigned RUST_LOG value in place instead of restoring the prior environment state.

**Files Needing Attention:** .github/workflows/railway-production.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/railway-production.yml | Updates tracing and backup-receipt verification correctly, but rollback does not restore a pre-existing custom RUST_LOG value. |
| scripts/railway-workflow.test.ts | Adds focused static assertions for the new logging filter and V3 receipt markers without introducing a functional issue. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rusty-auth%2Frustyauth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-railway-backup-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-railway-backup-gate%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A298%0A**RUST_LOG%20bypasses%20rollback%20restoration**%0A%0AIf%20the%20production%20environment%20has%20a%20customized%20%60RUST_LOG%60%20value%2C%20this%20assignment%20overwrites%20it%20while%20the%20failure%20handler%20restores%20only%20the%20captured%20browser-origin%20variables%2C%20leaving%20the%20rolled-back%20deployment%20without%20its%20previous%20logging%20configuration%20and%20potentially%20removing%20diagnostics%20configured%20for%20that%20deployment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=37&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frailway-production.yml%3A298%0A**RUST_LOG%20bypasses%20rollback%20restoration**%0A%0AIf%20the%20production%20environment%20has%20a%20customized%20%60RUST_LOG%60%20value%2C%20this%20assignment%20overwrites%20it%20while%20the%20failure%20handler%20restores%20only%20the%20captured%20browser-origin%20variables%2C%20leaving%20the%20rolled-back%20deployment%20without%20its%20previous%20logging%20configuration%20and%20potentially%20removing%20diagnostics%20configured%20for%20that%20deployment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rusty-auth%2Frustyauth&pr=37&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/railway-production.yml:298
**RUST_LOG bypasses rollback restoration**

If the production environment has a customized `RUST_LOG` value, this assignment overwrites it while the failure handler restores only the captured browser-origin variables, leaving the rolled-back deployment without its previous logging configuration and potentially removing diagnostics configured for that deployment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: verify Railway backup receipts"](https://github.com/rusty-auth/rustyauth/commit/3fbba8c1051331fa73e45dfb0d3a2e32e90ca15b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51637757)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->